### PR TITLE
Template improvements

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@
 # Prefix with VITE_ to make it available from the clientside
 
 # Sets the app name throughout the app, including the title and meta tags
-VITE_APP_NAME="App Template
+VITE_APP_NAME="App Template"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
+      - name: Check formatting
+        run: bun run format:check
       - name: Run tests
         run: bun test --pass-with-no-tests
       - name: Build project

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,26 @@
 {
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "README.md": "VISION.md,",
+    "package.json": "bun.lock, tsconfig.json, vite.config.ts, components.json, .oxlintrc.json, .oxfmtrc.json",
+    ".env": ".env.*"
+  },
   "files.associations": {
     "*.css": "tailwindcss"
   },
   "files.watcherExclude": {
     "**/routeTree.gen.ts": true,
-    "bun.lock": true
+    "bun.lock": true,
+    "dist": true,
+    ".tanstack": true
   },
   "search.exclude": {
     "**/routeTree.gen.ts": true,
-    "bun.lock": true
+    "bun.lock": true,
+    "dist": true,
+    ".tanstack": true
   },
   "files.readonlyInclude": {
     "**/routeTree.gen.ts": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "editor.formatOnSave": true,
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "README.md": "VISION.md,",
-    "package.json": "bun.lock, tsconfig.json, vite.config.ts, components.json, .oxlintrc.json, .oxfmtrc.json",
+    "README.md": "*.md",
+    "package.json": "bun.lock, tsconfig.json, vite.config.ts, *.json",
     ".env": ".env.*"
   },
   "files.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
   "explorer.fileNesting.patterns": {
     "README.md": "*.md",
     "package.json": "bun.lock, tsconfig.json, vite.config.ts, *.json",
-    ".env": ".env.*"
+    ".env": ".env.*",
+    "router.tsx": "routeTree.gen.ts"
   },
   "files.associations": {
     "*.css": "tailwindcss"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,4 +79,21 @@ Before editing files for a substantial task:
 ## Pull requests
 
 - Titles should be simple and easy to understand
-- Descriptions should open with a minimal, clear description of the problem, then follow with how the problem was solved.
+- Use the following template for the description:
+  ```md
+  ## What
+
+  <!-- one line summary -->
+
+  ## Why
+
+  <!-- dot point list of reasons for the change -->
+
+  ## How
+
+  <!-- dot point list of how the change was implemented, used nested dot points as required -->
+
+  ## Testing
+
+  <!-- list of checkboxes for testing -->
+  ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,10 @@ Before editing files for a substantial task:
   - `src/lib/env.ts` — client-readable variables, which must be prefixed with `VITE_`. Values come from `.env` (committed) and `.env.local` (gitignored, for secrets).
   - `src/lib/env.server.ts` — server-only variables.
 
-## Code Style
+## Coding Preferences
 
+- Apply the YAGNI and KISS principles
+- Keep things simple, robust and readable
 - Exports benefit from a short tsdoc comment describing intent and any non-obvious behaviour. Not required for every export — use judgment based on complexity. When you do add one, use the following format:
   ```ts
   /**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,12 @@ Before editing files for a substantial task:
 
 - [VISION.md](./VISION.md) — what this app does, who it's for, goals and non-goals
 
+## Planning
+
+- Before planning, check documentation using TanStack Intent
+- Always prefer simpler, robust solutions
+  - If you see a way to solve a problem simpler or most robustly, flag it with the user
+
 ## Project Structure
 
 - `src/lib` contains the project's library code, grouped by domain via this naming convention (e.g. for a `todos` domain):
@@ -61,12 +67,6 @@ Before editing files for a substantial task:
 - Always use Bun's test runner (`bun test`), see [the documentation](https://bun.com/docs/test.md) for more information.
 - Before writing tests, extract pure functions and presentational components out of framework wrappers (e.g. `createServerFn`, route files) so tests don't need runtime context.
 
-## Planning
-
-- Before planning, check documentation using TanStack Intent
-- Always prefer simpler, robust solutions
-  - If you see a way to solve a problem simpler or most robustly, flag it with the user
-
 ## User Interface
 
 - This project uses [shadcn/ui](https://ui.shadcn.com) components built on Tailwind CSS (v4) and Base UI.
@@ -75,3 +75,8 @@ Before editing files for a substantial task:
 - Tailwind is configured CSS-first via `src/styles.css`
 - Tailwind class sorting is handled by Oxfmt's `sortTailwindcss` option in `.oxfmtrc.json`, so classes are reordered automatically on format.
 - **Do not use `<Button render={<a />} nativeButton={false} />` for links.** The Base UI `Button` component always applies `role="button"`, which overrides the semantic link role on `<a>` elements. Use `buttonVariants` with a plain `<a>` tag instead.
+
+## Pull requests
+
+- Titles should be simple and easy to understand
+- Descriptions should open with a minimal, clear description of the problem, then follow with how the problem was solved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ Before editing files for a substantial task:
 
 <!-- intent-skills:end -->
 
+## Documentation
+
+- [VISION.md](./VISION.md) — what this app does, who it's for, goals and non-goals
+
 ## Project Structure
 
 - `src/lib` contains the project's library code, grouped by domain via this naming convention (e.g. for a `todos` domain):
@@ -29,6 +33,7 @@ Before editing files for a substantial task:
 
 - Apply the YAGNI and KISS principles
 - Keep things simple, robust and readable
+- Keep comments up to date with code changes
 - Exports benefit from a short tsdoc comment describing intent and any non-obvious behaviour. Not required for every export — use judgment based on complexity. When you do add one, use the following format:
   ```ts
   /**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # app-template
 
-<TODO>
+An opinionated app template built using TanStack Start, Bun, TailwindCSS and shadcn/ui
+
+## Template Setup
+
+> This section can be deleted after the initial setup
+
+### 1. Clone the template
+
+```bash
+# Clone the template repository
+git clone git@github.com:r-portas/app-template.git my-app
+cd my-app
+
+# Rename the remote to template so you can pull changes from the template in the future
+git remote rename origin template
+```
+
+### 2. Setup the app
+
+1. Update the `package.json` file with your app name
+2. Update the `README.md` file with your app name and description
+3. Update `VITE_APP_NAME` in the `.env` file with your app name
+4. Set `APP_ICON` in `src/components/app-layout.tsx` to the icon you want to use for your app
+
+### 3. Push changes
+
+```bash
+# Create a new repository on GitHub
+gh repo create <github-username>/<my-app> --private --source=. --remote=origin
+
+# Commit changes
+git add . && git commit -m "Init app"
+
+# Push
+git push -u origin main
+```
+
+### 4. Cleanup
+
+Delete this section from the README.md file
 
 ## Getting Started
 
@@ -38,6 +77,21 @@ bunx --bun skills add vercel-labs/agent-browser --global
 
 ```bash
 bunx --bun skills update --global
+```
+
+## Pull changes from the template
+
+Sync improvements made to the template repository into your app after the initial clone.
+
+```bash
+# Fetch the latest changes from the template repository
+git fetch template
+
+# Check what changes will be merged
+git log --oneline HEAD..template/main
+
+# Merge the changes into your local repository
+git merge template/main
 ```
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app-template
 
-An opinionated app template built using TanStack Start, Bun, TailwindCSS, and shadcn/ui
+An opinionated app template built using TanStack Start, Bun, Tailwind CSS, and shadcn/ui
 
 ## Template Setup
 
@@ -17,7 +17,7 @@ cd my-app
 git remote rename origin template
 ```
 
-### 2. Setup the app
+### 2. Set up the app
 
 1. Update the `package.json` file with your app name
 2. Update the `README.md` file with your app name and description
@@ -28,7 +28,7 @@ git remote rename origin template
 
 ```bash
 # Create a new repository on GitHub
-gh repo create <github-username>/<my-app> --private --source=. --remote=origin
+gh repo create github-username/my-app --private --source=. --remote=origin
 
 # Commit changes
 git add . && git commit -m "Init app"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app-template
 
-An opinionated app template built using TanStack Start, Bun, TailwindCSS and shadcn/ui
+An opinionated app template built using TanStack Start, Bun, TailwindCSS, and shadcn/ui
 
 ## Template Setup
 
@@ -41,6 +41,10 @@ git push -u origin main
 
 Delete this section from the README.md file
 
+## Documentation
+
+- [VISION.md](./VISION.md) — the purpose and goals of this app
+
 ## Getting Started
 
 ```bash
@@ -60,18 +64,14 @@ bun dev
 bun run update
 ```
 
-### Install Agent Browser
+## Environment variables
 
-```bash
-# Install the library globally
-bun install -g agent-browser
+Environment variables can be configured in one of two files:
 
-# Download Chrome
-agent-browser install
+- `.env` for non-secret configuration, this is committed in git
+- `.env.local` for secret configuration, this is gitignored. Copy `.env.local.example` to get started.
 
-# Install the skill
-bunx --bun skills add vercel-labs/agent-browser --global
-```
+## Common Tasks
 
 ### Update skills
 
@@ -79,7 +79,7 @@ bunx --bun skills add vercel-labs/agent-browser --global
 bunx --bun skills update --global
 ```
 
-## Pull changes from the template
+### Pull changes from the template
 
 Sync improvements made to the template repository into your app after the initial clone.
 
@@ -93,10 +93,3 @@ git log --oneline HEAD..template/main
 # Merge the changes into your local repository
 git merge template/main
 ```
-
-## Environment variables
-
-Environment variables can be configured in one of two files:
-
-- `.env` for non-secret configuration, this is committed in git
-- `.env.local` for secret configuration, this is gitignored. Copy `.env.local.example` to get started.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,26 @@
+# Vision
+
+## What this is
+
+An opinionated starting point for new full-stack apps, pre-wired with the stack, conventions, and tooling so a new project starts from a working app instead of a blank folder.
+
+## Why it exists
+
+Every new project pays the same setup tax: Setting up build tools, CI pipelines, frameworks and tools. That tax is worth paying once, not every time. This template captures those decisions so cloning it and running `bun dev` gets straight to building the actual app.
+
+## Goals
+
+- Clone-to-running in minutes, with a documented setup checklist ([README.md](README.md))
+- A clear, consistent project structure (`src/lib` domain modules split into server/functions/schemas/isomorphic) that scales as an app grows
+- Stay pullable: downstream apps can `git fetch template && git merge template/main` to absorb template improvements without rewriting their own code
+- Encode agent-facing conventions (CLAUDE.md, skills) so AI-assisted work on downstream apps starts from the same good defaults
+- Have a CI pipeline that works out of the box
+
+## Non-goals
+
+- Backwards compatibility guarantees for downstream apps — breaking changes are okay if they make new projects better; existing apps merge template updates at their own pace
+- Covering every possible app type (e.g. mobile, CLI tools) — this is for web apps built with TanStack Start
+
+## Roadmap
+
+1. Add built-in agent skills for configuring common things, like databases, deployment, etc.

--- a/VISION.md
+++ b/VISION.md
@@ -2,17 +2,18 @@
 
 ## What this is
 
-An opinionated starting point for new full-stack apps, pre-wired with the stack, conventions, and tooling so a new project starts from a working app instead of a blank folder.
+An opinionated starting point for full-stack applications, pre-configured with common tooling and best practices allowing you to hit the ground running with new projects.
 
 ## Why it exists
 
-Every new project pays the same setup tax: Setting up build tools, CI pipelines, frameworks and tools. That tax is worth paying once, not every time. This template captures those decisions so cloning it and running `bun dev` gets straight to building the actual app.
+Setting up a new project can involve setting up build tools, frameworks, libraries and other tooling.
+This template captures those decisions so that you can clone it and start building your app immediately.
 
 ## Goals
 
 - Clone-to-running in minutes, with a documented setup checklist ([README.md](README.md))
-- A clear, consistent project structure (`src/lib` domain modules split into server/functions/schemas/isomorphic) that scales as an app grows
-- Stay pullable: downstream apps can `git fetch template && git merge template/main` to absorb template improvements without rewriting their own code
+- Easily keep your app up to date with template improvements
+- A opinionated project structure (`src/lib` domain modules split into server/functions/schemas/isomorphic) that scales as an app grows
 - Encode agent-facing conventions (CLAUDE.md, skills) so AI-assisted work on downstream apps starts from the same good defaults
 - Have a CI pipeline that works out of the box
 

--- a/VISION.md
+++ b/VISION.md
@@ -25,3 +25,4 @@ This template captures those decisions so that you can clone it and start buildi
 ## Roadmap
 
 1. Add built-in agent skills for configuring common things, like databases, deployment, etc.
+2. Custom theme?

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "bun --bun vite dev",
     "build": "bun --bun vite build && tsc --noEmit && oxlint .",
     "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
     "update": "bun update --interactive --latest"
   },
   "dependencies": {

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -13,7 +13,7 @@ const APP_ICON = Blocks;
  * The items shown in the sidebar, each with an icon and a title.
  */
 const SIDEBAR_ITEMS: SidebarItem[] = [
-  { icon: Home, title: "Home", to: "/", activeOptions: { exact: true } }
+  { icon: Home, title: "Home", to: "/", activeOptions: { exact: true } },
 ];
 
 /**


### PR DESCRIPTION
## What

Fill out the template's docs, CI, and editor config, which were incomplete or inconsistent.

## Why

- README had a `<TODO>` placeholder instead of real setup instructions
- No vision doc existed to explain the template's purpose, goals, and non-goals
- CI didn't check formatting or use a frozen lockfile
- CLAUDE.md's guidance was disorganized

## How

- Add [VISION.md](../VISION.md) describing the template's purpose, goals, and non-goals
- Flesh out README.md with template setup steps, environment variable docs, and instructions for pulling template updates
- Reorganize and expand CLAUDE.md (coding preferences, pull request conventions, doc references)
- Add `format:check` script and run it in CI, alongside `--frozen-lockfile` installs
- Minor fixes: `.env` quoting, trailing comma lint, VS Code file-nesting/exclude settings

## Testing

- [x] `bun run format:check` passes
- [x] CI passes on this branch
