### PR TITLE
Add setup-skill authoring and review skills

### DIFF
--- a/.claude/setup-skill-template.md
+++ b/.claude/setup-skill-template.md
@@ -40,8 +40,8 @@ Read these before going beyond what the steps below cover.
 
 ## 0. Check it isn't already set up
 
-If `<sentinel file>` exists, <thing> is already configured. Stop here, tell the user what's
-already in place, and ask what they want changed.
+If `<sentinel file>` exists, <thing> is already configured. Stop here, tell the user what's already
+in place, and ask what they want changed.
 
 ## 1. Install dependencies
 
@@ -73,15 +73,12 @@ example and tell the agent to ask the user what they actually need.>
 
 ## 4. Document the convention
 
-<The block to append to `CLAUDE.md`, covering what a future agent needs to work with this
-without breaking it.>
+<The block to append to `CLAUDE.md`, covering what a future agent needs to work with this without
+breaking it.>
 
 ## 5. Verify
 
-\`\`\`bash
-bun run format
-bun run build
-\`\`\`
+\`\`\`bash bun run format bun run build \`\`\`
 
 <What "working" looks like beyond a green build.>
 
@@ -98,8 +95,8 @@ A skill matching this template satisfies all of these:
 
 1. **`name` matches the directory name**, and the directory is `setup-<thing>`.
 2. **`description` states the situation that should trigger the skill**, phrased so it fires when a
-   user describes the problem rather than naming the tool. It is the only part loaded every
-   session, so it does the invocation work alone.
+   user describes the problem rather than naming the tool. It is the only part loaded every session,
+   so it does the invocation work alone.
 3. **Step 0's sentinel-file guard exists because re-running a setup over a live project overwrites
    work.**
 4. **An `## Important Caveats` section appears above `## Documentation`** whenever the setup has a
@@ -127,15 +124,15 @@ A skill matching this template satisfies all of these:
    `setup-drizzle`'s `@rc5` is the shape: a pre-1.0 package whose API only matches that tag.
 8. **A "Document the convention" step exists** whenever there is ongoing guidance a future agent
    needs — which is most setups, hosting config being the usual exception.
-9. **The final step runs the project's real build**, so a wrong guide fails during setup rather
-   than silently later.
+9. **The final step runs the project's real build**, so a wrong guide fails during setup rather than
+   silently later.
 10. **A Documentation section covers every library whose API this skill encodes**, each with a
     reference and a changelog. The reference is the agent's escape hatch when the user asks for
     something the steps don't cover; the changelog is what a review pass diffs against to find rot.
     - A library the skill merely installs without encoding its API needs no entry — the test is
       whether an upstream change could break these steps.
-    - A skipped changelog needs its reason recorded, so a review pass can tell a considered
-      omission from an oversight.
+    - A skipped changelog needs its reason recorded, so a review pass can tell a considered omission
+      from an oversight.
 11. **A step with more than one clearly separate concern splits into numbered `###` subheadings**,
     e.g. `### 2.1 <sub-part>`, `### 2.2 <sub-part>`. `setup-drizzle`'s step 5 is the shape: "Define
     the schema" covers the tables every setup needs, and a follow-on "Relations" subsection splits

--- a/.claude/setup-skill-template.md
+++ b/.claude/setup-skill-template.md
@@ -58,10 +58,18 @@ already in place, and ask what they want changed.
   - <specific>
   - <specific>
 
+### 2.1 <Distinct sub-part of configuration, e.g. a second config file or a separable option>
+
+<Only when this step covers more than one clearly separate concern — see rule 11.>
+
 ## 3. Write the code
 
 <The scaffolding, following the `src/lib` domain convention. Mark anything app-specific as an
 example and tell the agent to ask the user what they actually need.>
+
+### 3.1 <Distinct sub-part of the scaffolding, e.g. a follow-on concern the base code doesn't need>
+
+<Same rule as step 2 — only split out when the sub-part is separable, not for every step.>
 
 ## 4. Document the convention
 
@@ -92,20 +100,19 @@ A skill matching this template satisfies all of these:
 2. **`description` states the situation that should trigger the skill**, phrased so it fires when a
    user describes the problem rather than naming the tool. It is the only part loaded every
    session, so it does the invocation work alone.
-3. **The intro is one line** saying what the setup adds.
-4. **Step 0 guards on a specific sentinel file** whose existence proves the setup already ran, and
-   stops to ask rather than proceeding. Re-running a setup over a live project overwrites work.
-5. **An `## Important Caveats` section appears above `## Documentation`** whenever the setup has a
+3. **Step 0's sentinel-file guard exists because re-running a setup over a live project overwrites
+   work.**
+4. **An `## Important Caveats` section appears above `## Documentation`** whenever the setup has a
    sharp edge — a pin that will go stale, or a neighbouring case this skill is wrong for. It sits
    first because it decides whether to run the skill at all.
    - Optional, and left out entirely when there is no sharp edge. Unlike a missing changelog, an
      absence needs no explanation: whether a setup has a sharp edge is a judgment a review pass
      re-derives from the steps anyway.
-   - A caveat spans the whole setup. A fact about one line in one step is a rule 7 explanation
+   - A caveat spans the whole setup. A fact about one line in one step is a rule 6 explanation
      instead, and belongs in that step.
-6. **App-specific code is marked as illustrative**, paired with an instruction to ask the user what
-   they're modelling. Schemas, routes, and components are examples; scaffolding is not.
-7. **Non-obvious commands and config keys are explained in a bullet list at the end of their
+5. **App-specific code is marked as illustrative.** Schemas, routes, and components are examples;
+   scaffolding is not.
+6. **Non-obvious commands and config keys are explained in a bullet list at the end of their
    section**, below the code block rather than woven into prose around it:
    - One bullet per item, opening with the flag, key, or command in backticks so the list scans.
    - Give the _why_ — what it is there for, or what breaks without it — rather than restating what
@@ -115,19 +122,22 @@ A skill matching this template satisfies all of these:
      parent states the point, the children carry the specifics. `setup-drizzle`'s
      `defineRelations()` warning is the shape — what changed as the parent, then "not exported in
      this version" and "fails at runtime, not at the type level" as children.
-8. **Dependencies install at their latest version.** A pin is the exception, and has to justify
+7. **Dependencies install at their latest version.** A pin is the exception, and has to justify
    itself in the step's bullet list — why this version, and what to check when it goes stale.
    `setup-drizzle`'s `@rc5` is the shape: a pre-1.0 package whose API only matches that tag.
-9. **A "Document the convention" step exists** whenever there is ongoing guidance a future agent
+8. **A "Document the convention" step exists** whenever there is ongoing guidance a future agent
    needs — which is most setups, hosting config being the usual exception.
-10. **The final step runs the project's real build**, so a wrong guide fails during setup rather
-    than silently later, and ends by handing off to the user.
-11. **A Documentation section covers every library whose API this skill encodes**, each with a
+9. **The final step runs the project's real build**, so a wrong guide fails during setup rather
+   than silently later.
+10. **A Documentation section covers every library whose API this skill encodes**, each with a
     reference and a changelog. The reference is the agent's escape hatch when the user asks for
     something the steps don't cover; the changelog is what a review pass diffs against to find rot.
-    A docs homepage serves neither — prefer an `llms.txt` and a releases page.
-    - A library the skill merely installs without encoding its API needs no entry. The test is
+    - A library the skill merely installs without encoding its API needs no entry — the test is
       whether an upstream change could break these steps.
-    - Where a changelog is too broad to be useful — a runtime's release notes against the one
-      module this skill touches — keep the key and record why it was skipped, so a review pass can
-      tell a considered omission from an oversight.
+    - A skipped changelog needs its reason recorded, so a review pass can tell a considered
+      omission from an oversight.
+11. **A step with more than one clearly separate concern splits into numbered `###` subheadings**,
+    e.g. `### 2.1 <sub-part>`, `### 2.2 <sub-part>`. `setup-drizzle`'s step 5 is the shape: "Define
+    the schema" covers the tables every setup needs, and a follow-on "Relations" subsection splits
+    off a concern that's separable enough to skip or return to later. Don't split a step whose
+    content is a single continuous concern just to have subheadings.

--- a/.claude/setup-skill-template.md
+++ b/.claude/setup-skill-template.md
@@ -1,0 +1,133 @@
+# Setup Skill Template
+
+The shape every `/setup-*` skill in `.claude/skills/` follows. `draft-setup-skill` fills this in
+when writing a new one; a review pass checks existing skills against the rules below.
+
+A setup skill is a **one-time** guide: it adds a tool or integration to a project that doesn't have
+it. Ongoing guidance — how to work with the tool afterwards — belongs in `CLAUDE.md`, which is what
+the "Document the convention" step is for.
+
+## Structure
+
+```md
+---
+name: setup-<thing>
+description: <the situation that should trigger this skill>
+---
+
+# Setup <Thing>
+
+One-time setup that <what it adds, in one line>.
+
+## Important Caveats
+
+<Omit this section entirely when the setup has no sharp edge.>
+
+- <The point, e.g. the case where this is the wrong skill and the user wants something else>
+  - <specific>
+  - <specific>
+
+## Documentation
+
+- <Library>
+  - Reference: <canonical docs, preferring an `llms.txt` where the project publishes one>
+  - Changelog: <releases or changelog page>
+- <Library whose changelog is too broad to be useful>
+  - Reference: <...>
+  - Changelog: omitted — <why, in one line>
+
+Read these before going beyond what the steps below cover.
+
+## 0. Check it isn't already set up
+
+If `<sentinel file>` exists, <thing> is already configured. Stop here, tell the user what's
+already in place, and ask what they want changed.
+
+## 1. Install dependencies
+
+<Commands, installing the latest version unless a pin is justified below.>
+
+- `<package@pin>` — <why this version is pinned, and what to check when it goes stale>
+
+## 2. Configure
+
+<Config files, environment variables, package.json scripts.>
+
+- `<flag or key>` — <why it is there, or what breaks without it>
+- `<flag or key>` — <the point, when it needs more than one line>
+  - <specific>
+  - <specific>
+
+## 3. Write the code
+
+<The scaffolding, following the `src/lib` domain convention. Mark anything app-specific as an
+example and tell the agent to ask the user what they actually need.>
+
+## 4. Document the convention
+
+<The block to append to `CLAUDE.md`, covering what a future agent needs to work with this
+without breaking it.>
+
+## 5. Verify
+
+\`\`\`bash
+bun run format
+bun run build
+\`\`\`
+
+<What "working" looks like beyond a green build.>
+
+Then tell the user what changed and how to drive it, pointing at the scripts and the `CLAUDE.md`
+section this skill just wrote rather than restating them.
+```
+
+Step count is not fixed — split or merge the middle steps to fit the setup. The ordering (guard →
+install → configure → code → document → verify) is.
+
+## Rules
+
+A skill matching this template satisfies all of these:
+
+1. **`name` matches the directory name**, and the directory is `setup-<thing>`.
+2. **`description` states the situation that should trigger the skill**, phrased so it fires when a
+   user describes the problem rather than naming the tool. It is the only part loaded every
+   session, so it does the invocation work alone.
+3. **The intro is one line** saying what the setup adds.
+4. **Step 0 guards on a specific sentinel file** whose existence proves the setup already ran, and
+   stops to ask rather than proceeding. Re-running a setup over a live project overwrites work.
+5. **An `## Important Caveats` section appears above `## Documentation`** whenever the setup has a
+   sharp edge — a pin that will go stale, or a neighbouring case this skill is wrong for. It sits
+   first because it decides whether to run the skill at all.
+   - Optional, and left out entirely when there is no sharp edge. Unlike a missing changelog, an
+     absence needs no explanation: whether a setup has a sharp edge is a judgment a review pass
+     re-derives from the steps anyway.
+   - A caveat spans the whole setup. A fact about one line in one step is a rule 7 explanation
+     instead, and belongs in that step.
+6. **App-specific code is marked as illustrative**, paired with an instruction to ask the user what
+   they're modelling. Schemas, routes, and components are examples; scaffolding is not.
+7. **Non-obvious commands and config keys are explained in a bullet list at the end of their
+   section**, below the code block rather than woven into prose around it:
+   - One bullet per item, opening with the flag, key, or command in backticks so the list scans.
+   - Give the _why_ — what it is there for, or what breaks without it — rather than restating what
+     the line already says. `framework: null` stopping Vercel's detection is a why; "sets framework
+     to null" is not.
+   - Detail running past one line nests under its own bullet rather than sprawling into prose: the
+     parent states the point, the children carry the specifics. `setup-drizzle`'s
+     `defineRelations()` warning is the shape — what changed as the parent, then "not exported in
+     this version" and "fails at runtime, not at the type level" as children.
+8. **Dependencies install at their latest version.** A pin is the exception, and has to justify
+   itself in the step's bullet list — why this version, and what to check when it goes stale.
+   `setup-drizzle`'s `@rc5` is the shape: a pre-1.0 package whose API only matches that tag.
+9. **A "Document the convention" step exists** whenever there is ongoing guidance a future agent
+   needs — which is most setups, hosting config being the usual exception.
+10. **The final step runs the project's real build**, so a wrong guide fails during setup rather
+    than silently later, and ends by handing off to the user.
+11. **A Documentation section covers every library whose API this skill encodes**, each with a
+    reference and a changelog. The reference is the agent's escape hatch when the user asks for
+    something the steps don't cover; the changelog is what a review pass diffs against to find rot.
+    A docs homepage serves neither — prefer an `llms.txt` and a releases page.
+    - A library the skill merely installs without encoding its API needs no entry. The test is
+      whether an upstream change could break these steps.
+    - Where a changelog is too broad to be useful — a runtime's release notes against the one
+      module this skill touches — keep the key and record why it was skipped, so a review pass can
+      tell a considered omission from an oversight.

--- a/.claude/setup-skill-template.md
+++ b/.claude/setup-skill-template.md
@@ -9,7 +9,7 @@ the "Document the convention" step is for.
 
 ## Structure
 
-```md
+````md
 ---
 name: setup-<thing>
 description: <the situation that should trigger this skill>
@@ -78,13 +78,16 @@ breaking it.>
 
 ## 5. Verify
 
-\`\`\`bash bun run format bun run build \`\`\`
+```bash
+bun run format
+bun run build
+```
 
 <What "working" looks like beyond a green build.>
 
 Then tell the user what changed and how to drive it, pointing at the scripts and the `CLAUDE.md`
 section this skill just wrote rather than restating them.
-```
+````
 
 Step count is not fixed — split or merge the middle steps to fit the setup. The ordering (guard →
 install → configure → code → document → verify) is.

--- a/.claude/skills/draft-setup-skill/SKILL.md
+++ b/.claude/skills/draft-setup-skill/SKILL.md
@@ -35,7 +35,7 @@ Read [`.claude/setup-skill-template.md`](../../setup-skill-template.md) — it h
 fill in and the rules the finished skill has to satisfy. `setup-drizzle` is the closest worked
 example if the template leaves something ambiguous.
 
-**Done when** you can name the ten rules the draft will be checked against.
+**Done when** you can name all the rules in the template the draft will be checked against.
 
 ## 3. Draft the skeleton
 
@@ -87,7 +87,7 @@ lands in a specific slot:
 | 6 Wrong-tool boundary      | the `Important Caveats` section                      |
 | 7 Documentation            | the Documentation section                            |
 
-**Done when** every interview answer appears in its slot and the draft satisfies all eleven rules in
+**Done when** every interview answer appears in its slot and the draft satisfies all the rules in
 the template.
 
 ## 6. Wire it up

--- a/.claude/skills/draft-setup-skill/SKILL.md
+++ b/.claude/skills/draft-setup-skill/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: draft-setup-skill
-description: Use after manually setting up a tool or integration, to capture it as a reusable `/setup-*` skill. Reads the change set on disk, interviews the user about what the diff cannot show, and writes the SKILL.md.
+description:
+  Use after manually setting up a tool or integration, to capture it as a reusable `/setup-*` skill.
+  Reads the change set on disk, interviews the user about what the diff cannot show, and writes the
+  SKILL.md.
 ---
 
 # Draft Setup Skill
@@ -44,8 +47,8 @@ ground the interview in specifics, so keep it rough.
 ## 4. Interview the user
 
 Ask all seven questions below with `AskUserQuestion`, using the skeleton to make each one concrete
-("I see `drizzle.config.ts` reads `process.env` directly rather than importing the env module —
-was that deliberate?"). Batch them into as few calls as the tool allows.
+("I see `drizzle.config.ts` reads `process.env` directly rather than importing the env module — was
+that deliberate?"). Batch them into as few calls as the tool allows.
 
 1. **Sentinel** — which file's existence proves this is already set up?
 2. **Dead ends** — what did you try first that didn't work, and how did it fail? Distinguish a type
@@ -61,9 +64,9 @@ was that deliberate?"). Batch them into as few calls as the tool allows.
 6. **Wrong-tool boundary** — when should someone reach for something else instead?
 7. **Documentation** — list every library whose API the skill encodes, not every package it
    installs. Find each one's reference and changelog yourself, then put the set to the user to
-   confirm. An `llms.txt` beats a docs site; a releases page beats a homepage, because a review
-   pass reads it to decide whether the skill has rotted. Where a changelog would be too broad to
-   isolate the relevant changes, propose skipping it and record the reason.
+   confirm. An `llms.txt` beats a docs site; a releases page beats a homepage, because a review pass
+   reads it to decide whether the skill has rotted. Where a changelog would be too broad to isolate
+   the relevant changes, propose skipping it and record the reason.
 
 Every answer comes from the user. When one is missing, ask again.
 
@@ -84,8 +87,8 @@ lands in a specific slot:
 | 6 Wrong-tool boundary      | the `Important Caveats` section                      |
 | 7 Documentation            | the Documentation section                            |
 
-**Done when** every interview answer appears in its slot and the draft satisfies all eleven rules
-in the template.
+**Done when** every interview answer appears in its slot and the draft satisfies all eleven rules in
+the template.
 
 ## 6. Wire it up
 

--- a/.claude/skills/draft-setup-skill/SKILL.md
+++ b/.claude/skills/draft-setup-skill/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: draft-setup-skill
+description: Use after manually setting up a tool or integration, to capture it as a reusable `/setup-*` skill. Reads the change set on disk, interviews the user about what the diff cannot show, and writes the SKILL.md.
+---
+
+# Draft Setup Skill
+
+Turns a setup you just performed by hand into a `/setup-*` skill. The change set on disk is the
+skeleton; the **interview** in step 4 is where the value is. A skill written from the diff alone is
+a transcription — no better than the diff itself, and it will mislead the next reader.
+
+## 1. Gather the change set
+
+Establish what actually changed. Ask the user for the base to compare against if it isn't obvious
+(usually `main`, or `HEAD` for uncommitted work):
+
+```bash
+git status --short
+git diff <base> --stat
+git diff <base>
+```
+
+Record the exact installed version of every added package from the `package.json` diff and
+`bun.lock` — a floating `^1.2.0` in the diff may have resolved to something the skill needs to pin.
+
+**Done when** you can name every changed file and every added package with the version that is
+actually installed.
+
+## 2. Read the template
+
+Read [`.claude/setup-skill-template.md`](../../setup-skill-template.md) — it holds the structure to
+fill in and the rules the finished skill has to satisfy. `setup-drizzle` is the closest worked
+example if the template leaves something ambiguous.
+
+**Done when** you can name the ten rules the draft will be checked against.
+
+## 3. Draft the skeleton
+
+Write the numbered steps only — headings and commands, no explanatory prose yet. This exists to
+ground the interview in specifics, so keep it rough.
+
+**Done when** every file in the change set is accounted for by some step.
+
+## 4. Interview the user
+
+Ask all seven questions below with `AskUserQuestion`, using the skeleton to make each one concrete
+("I see `drizzle.config.ts` reads `process.env` directly rather than importing the env module —
+was that deliberate?"). Batch them into as few calls as the tool allows.
+
+1. **Sentinel** — which file's existence proves this is already set up?
+2. **Dead ends** — what did you try first that didn't work, and how did it fail? Distinguish a type
+   error from a runtime error; a wrong turn that typechecks is the one worth warning about. If the
+   answer is "nothing surprised me", ask once more — a setup worth capturing as a skill almost
+   always had one.
+3. **Version fragility** — which pins are deliberate, and what breaks when they go stale?
+4. **Verbatim vs. illustrative** — which parts of the diff are this app's specific content (a
+   schema, a route, a component) rather than required scaffolding? Illustrative code gets marked as
+   an example in the skill, with an instruction to ask the user what they're modelling.
+5. **Ongoing convention** — what does a future agent need in `CLAUDE.md` to work with this without
+   breaking it?
+6. **Wrong-tool boundary** — when should someone reach for something else instead?
+7. **Documentation** — list every library whose API the skill encodes, not every package it
+   installs. Find each one's reference and changelog yourself, then put the set to the user to
+   confirm. An `llms.txt` beats a docs site; a releases page beats a homepage, because a review
+   pass reads it to decide whether the skill has rotted. Where a changelog would be too broad to
+   isolate the relevant changes, propose skipping it and record the reason.
+
+Every answer comes from the user. When one is missing, ask again.
+
+**Done when** all seven have an answer you could quote back.
+
+## 5. Write the SKILL.md
+
+Create `.claude/skills/setup-<thing>/SKILL.md` from the template's structure. Each interview answer
+lands in a specific slot:
+
+| Answer                     | Slot                                                 |
+| -------------------------- | ---------------------------------------------------- |
+| 1 Sentinel                 | the file named in step 0                             |
+| 2 Dead ends                | inline warnings beside the step each one belongs to  |
+| 3 Version fragility        | the pin, plus what to check when it goes stale       |
+| 4 Verbatim vs illustrative | the example markers and the ask-the-user instruction |
+| 5 Ongoing convention       | the "Document the convention" block                  |
+| 6 Wrong-tool boundary      | the `Important Caveats` section                      |
+| 7 Documentation            | the Documentation section                            |
+
+**Done when** every interview answer appears in its slot and the draft satisfies all eleven rules
+in the template.
+
+## 6. Wire it up
+
+- Add the skill to the list under "Set up additional tooling" in `README.md`.
+- Update the setup-skills item in the `VISION.md` roadmap if this completes something listed there.
+
+## 7. Verify
+
+Confirm the skill works against a project that hasn't had the setup applied — the branch point from
+step 1 is the natural candidate:
+
+```bash
+git stash            # or check out the base in a worktree
+```
+
+Follow the drafted skill start to finish as written, then run the project's build. Anywhere you had
+to improvise is a gap in the skill; fix it there and rerun rather than working around it.
+
+**Done when** the build passes having followed only what the skill says.

--- a/.claude/skills/review-setup-skills/SKILL.md
+++ b/.claude/skills/review-setup-skills/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: review-setup-skills
-description: Reviews and updates existing `/setup-*` skills — checks structure against setup-skill-template.md and diffs each skill's steps against the upstream libraries' current documentation and changelog. Use when a `/setup-*` skill needs checking or refreshing for drift. Takes an optional skill name; omitted means review every `setup-*` skill.
+description:
+  Reviews and updates existing `/setup-*` skills — checks structure against setup-skill-template.md
+  and diffs each skill's steps against the upstream libraries' current documentation and changelog.
+  Use when a `/setup-*` skill needs checking or refreshing for drift. Takes an optional skill name;
+  omitted means review every `setup-*` skill.
 ---
 
 # Review Setup Skills
@@ -29,9 +33,8 @@ Parse the optional skill-name argument.
 
 ## 2. Read the template
 
-Read `.claude/setup-skill-template.md` in full and hold its rules — they're what step 3's
-structural pass checks against. Reread it here rather than relying on a stale summary from a
-previous run.
+Read `.claude/setup-skill-template.md` in full and hold its rules — they're what step 3's structural
+pass checks against. Reread it here rather than relying on a stale summary from a previous run.
 
 **Done when** you can name every rule in the template from memory.
 
@@ -42,8 +45,8 @@ and upstream findings belong in one report, not two.
 
 ### 3.1 Structural pass
 
-Check the skill against every rule in the template. For each violation, note the rule number,
-what's wrong, and where.
+Check the skill against every rule in the template. For each violation, note the rule number, what's
+wrong, and where.
 
 A few are easy to miss on a skim, so check them deliberately:
 
@@ -87,8 +90,8 @@ spot-checked.
 
 ## 4. Decide what to fix directly vs. what to ask about
 
-Structural violations and confirmed version bumps that don't change the API are safe to fix
-directly — they don't change what the skill recommends, only bring the file in line with itself.
+Structural violations and confirmed version bumps that don't change the API are safe to fix directly
+— they don't change what the skill recommends, only bring the file in line with itself.
 
 Anything that changes the _recommendation_ — a new pin, a config shape that moved, a best-practice
 change, a dead changelog link — needs a judgment call the user should make, since it changes what
@@ -99,9 +102,8 @@ if there's only one skill and one finding) before editing.
 
 ## 5. Apply the fixes
 
-Edit each `SKILL.md` in place. Keep the template's step ordering (guard → install → configure →
-code → document → verify) — a fix that reorders steps needs the same justification a new skill
-would.
+Edit each `SKILL.md` in place. Keep the template's step ordering (guard → install → configure → code
+→ document → verify) — a fix that reorders steps needs the same justification a new skill would.
 
 Update the `Documentation` section's links if any moved, and update a pin's justification bullet if
 the reason behind it changed.

--- a/.claude/skills/review-setup-skills/SKILL.md
+++ b/.claude/skills/review-setup-skills/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: review-setup-skills
+description: Reviews and updates existing `/setup-*` skills — checks structure against setup-skill-template.md and diffs each skill's steps against the upstream libraries' current documentation and changelog. Use when asked to audit, review, refresh, or update setup skills, check whether a setup skill is stale or out of date, or verify a skill still matches upstream best practice. Takes an optional skill name; omitted means review every `setup-*` skill.
+---
+
+# Review Setup Skills
+
+Audits one or all `/setup-*` skills against
+[`setup-skill-template.md`](../../setup-skill-template.md) and against the current state of the
+libraries they encode, then fixes what's out of date.
+
+Two kinds of drift, checked separately:
+
+- **Structural** — the skill no longer satisfies the template's rules. Found by rereading the file.
+- **Upstream** — the library moved and the skill still describes the old shape. Found by fetching
+  the docs, not by rereading the file.
+
+## 1. Resolve scope
+
+Parse the optional skill-name argument.
+
+- Given — normalize it to a directory name (`setup-<thing>`, stripping a leading `/` or `setup-` if
+  the user included one) and confirm `.claude/skills/<name>/SKILL.md` exists. Stop and ask if it
+  doesn't; a typo here would silently review nothing.
+- Omitted — glob `.claude/skills/setup-*/SKILL.md`. Skip a directory with no `SKILL.md` — that's a
+  skill still being drafted, not one to review.
+
+**Done when** you have the exact list of `SKILL.md` files to review.
+
+## 2. Read the template
+
+Read `.claude/setup-skill-template.md` in full and hold its eleven rules — they're what step 3's
+structural pass checks against. Reread it here rather than relying on a stale summary from a
+previous run.
+
+**Done when** you can name the eleven rules from memory.
+
+## 3. Review each skill
+
+For every file from step 1, run both passes before moving to the next skill — a skill's structural
+and upstream findings belong in one report, not two.
+
+### 3.1 Structural pass
+
+Check the skill against each of the template's eleven rules. For each violation, note the rule
+number, what's wrong, and where.
+
+A few are easy to miss on a skim, so check them deliberately:
+
+- `description` is still phrased as the situation that triggers the skill, not just the tool's name
+  (rule 2).
+- Every non-obvious command or config key still has its explanatory bullet below the block, not
+  folded into prose (rule 6).
+- A pin still carries its justification and stale-check instructions (rule 7) — or, if the package
+  has since hit a stable 1.0, the pin itself may no longer be needed.
+- The `Documentation` section still lists every library the steps encode, not just the ones
+  installed (rule 10).
+
+### 3.2 Upstream pass
+
+For each entry in the skill's `Documentation` section, fetch the reference and — if not omitted —
+the changelog with `WebFetch`. Then check, in order:
+
+1. **Version drift** — does the pin (or "latest") in step 1's install command still match what's
+   actually current? Check the package's own dist-tags (e.g. `npm view <package> dist-tags --json`)
+   rather than trusting a doc page's version number, which can lag.
+2. **API drift** — do the exports, config shape, and flags the skill's code blocks use still exist
+   and mean the same thing? A renamed export or changed default is worth flagging even when the
+   skill's version pin is still technically installable.
+3. **Best-practice drift** — does the current documentation recommend the same approach the skill
+   teaches, or has it since suggested something else (a new canonical pattern, a flag the skill uses
+   that's now deprecated)? This is a judgment call, not a diff — read the docs' own guidance, not
+   just its reference material.
+4. **Changelog scan** — walk entries since the version the skill currently pins (or since 1.0 if no
+   version is recorded) for anything that changes what steps 1 through N describe. If the skill's
+   changelog is "omitted" with a reason, confirm that reason still holds — a package can grow a real
+   changelog after the skill was written.
+
+A skipped changelog needing no changes and clean docs both count as a real check — record "checked,
+no drift" for the skill's next review, not silence.
+
+**Done when** every `Documentation` entry for the skill has been fetched and compared, not just
+spot-checked.
+
+## 4. Decide what to fix directly vs. what to ask about
+
+Structural violations and confirmed version bumps that don't change the API are safe to fix
+directly — they don't change what the skill recommends, only bring the file in line with itself.
+
+Anything that changes the _recommendation_ — a new pin, a config shape that moved, a best-practice
+change, a dead changelog link — needs a judgment call the user should make, since it changes what
+the skill tells the next agent to build. Batch these into one `AskUserQuestion` (or a plain summary
+if there's only one skill and one finding) before editing.
+
+**Done when** every finding is sorted into "fix directly" or "confirm with the user first".
+
+## 5. Apply the fixes
+
+Edit each `SKILL.md` in place. Keep the template's step ordering (guard → install → configure →
+code → document → verify) — a fix that reorders steps needs the same justification a new skill
+would.
+
+Update the `Documentation` section's links if any moved, and update a pin's justification bullet if
+the reason behind it changed.
+
+## 6. Report
+
+Per skill reviewed, summarize:
+
+- What was fixed — structural and upstream, each in one line.
+- What's confirmed current, so this doubles as a record for the next review pass.
+- What still needs the user's call, if step 4 surfaced anything unresolved.
+
+Don't re-run the project's build — a `SKILL.md` isn't executable, so nothing here is verified by
+`bun run build`. The real verification is following the skill start-to-finish against a fresh
+project; that's `draft-setup-skill`'s step 7 concern, not this pass's.

--- a/.claude/skills/review-setup-skills/SKILL.md
+++ b/.claude/skills/review-setup-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-setup-skills
-description: Reviews and updates existing `/setup-*` skills — checks structure against setup-skill-template.md and diffs each skill's steps against the upstream libraries' current documentation and changelog. Use when asked to audit, review, refresh, or update setup skills, check whether a setup skill is stale or out of date, or verify a skill still matches upstream best practice. Takes an optional skill name; omitted means review every `setup-*` skill.
+description: Reviews and updates existing `/setup-*` skills — checks structure against setup-skill-template.md and diffs each skill's steps against the upstream libraries' current documentation and changelog. Use when a `/setup-*` skill needs checking or refreshing for drift. Takes an optional skill name; omitted means review every `setup-*` skill.
 ---
 
 # Review Setup Skills
@@ -29,11 +29,11 @@ Parse the optional skill-name argument.
 
 ## 2. Read the template
 
-Read `.claude/setup-skill-template.md` in full and hold its eleven rules — they're what step 3's
+Read `.claude/setup-skill-template.md` in full and hold its rules — they're what step 3's
 structural pass checks against. Reread it here rather than relying on a stale summary from a
 previous run.
 
-**Done when** you can name the eleven rules from memory.
+**Done when** you can name every rule in the template from memory.
 
 ## 3. Review each skill
 
@@ -42,8 +42,8 @@ and upstream findings belong in one report, not two.
 
 ### 3.1 Structural pass
 
-Check the skill against each of the template's eleven rules. For each violation, note the rule
-number, what's wrong, and where.
+Check the skill against every rule in the template. For each violation, note the rule number,
+what's wrong, and where.
 
 A few are easy to miss on a skim, so check them deliberately:
 
@@ -55,6 +55,9 @@ A few are easy to miss on a skim, so check them deliberately:
   has since hit a stable 1.0, the pin itself may no longer be needed.
 - The `Documentation` section still lists every library the steps encode, not just the ones
   installed (rule 10).
+
+**Done when** every rule in the template has been checked against the skill, not just the four
+above.
 
 ### 3.2 Upstream pass
 
@@ -102,6 +105,9 @@ would.
 
 Update the `Documentation` section's links if any moved, and update a pin's justification bullet if
 the reason behind it changed.
+
+**Done when** every fix sorted into "fix directly" in step 4 is applied and saved, across every
+skill in scope — not just the first one.
 
 ## 6. Report
 

--- a/.claude/skills/setup-drizzle/SKILL.md
+++ b/.claude/skills/setup-drizzle/SKILL.md
@@ -78,20 +78,17 @@ const serverEnvSchema = z.object({
 export default serverEnvSchema.parse(process.env);
 ```
 
-The database path is non-secret configuration, so it belongs in `.env` (committed) rather than
-`.env.local`:
-
 ```bash
 DATABASE_URL=file:./local.db
 ```
 
-Add the database file to `.gitignore`. Bun's SQLite driver defaults to WAL mode, which creates
-`-shm`/`-wal` sidecar files alongside it — ignore those too:
+- Belongs in `.env` (committed) rather than `.env.local` — the database path is non-secret
+  configuration
+
+Add the database file to `.gitignore`:
 
 ```
 local.db
-local.db-shm
-local.db-wal
 ```
 
 ## 4. Create the config
@@ -138,8 +135,8 @@ export const notesTable = sqliteTable("notes", {
 });
 ```
 
-`int({ mode: "timestamp_ms" })` stores timestamps as milliseconds since epoch and maps them to JS
-`Date` objects — assign `new Date()` or `Date.now()` directly.
+- `int({ mode: "timestamp_ms" })` — stores timestamps as milliseconds since epoch and maps them to
+  JS `Date` objects; assign `new Date()` or `Date.now()` directly
 
 ### 5.1 Relations
 
@@ -174,9 +171,8 @@ export const relations = defineRelations(schema, (r) => ({
     actually runs
   - The relational API changed shape once during the beta/rc cycle and may change again
 
-For a many-to-many relation through a join table, chain `.through()` on both sides' columns instead
-of writing relations on the join table itself — `db.query` then traverses the join table implicitly.
-Illustrative only; `tagsTable`/`noteTagsTable` aren't part of the example schema above:
+For a many-to-many relation through a join table, illustrative only; `tagsTable`/`noteTagsTable`
+aren't part of the example schema above:
 
 ```ts
 tagsTable: {
@@ -186,6 +182,9 @@ tagsTable: {
   }),
 },
 ```
+
+- `.through()` — chained on both sides' columns instead of writing relations on the join table
+  itself; `db.query` then traverses the join table implicitly
 
 ## 6. Create the client
 
@@ -258,8 +257,7 @@ bun run format
 bun run build
 ```
 
-`drizzle:push` is the development fast path: no migration files, just push and query. For
-production, use `drizzle-kit generate` to produce tracked SQL migration files, then
-`drizzle-kit migrate` to apply them.
-
-Browse the database in Drizzle Studio with `bun drizzle:studio`.
+- `drizzle:push` — the development fast path, pushing the schema directly with no migration files
+  - For production, use `drizzle-kit generate` then `drizzle-kit migrate` instead (see the
+    `CLAUDE.md` section written in the step above)
+- `bun drizzle:studio` — browse the database in Drizzle Studio

--- a/.claude/skills/setup-drizzle/SKILL.md
+++ b/.claude/skills/setup-drizzle/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: setup-drizzle
+description: Adds a database to the project using Drizzle ORM with Bun's native SQLite driver
+---
+
+# Setup Drizzle
+
+One-time setup that adds Drizzle ORM with Bun's native SQLite driver.
+
+## Important Caveats
+
+- Drizzle is pre-1.0, so install `drizzle-orm@rc5` and `drizzle-kit@rc5` exactly as shown below
+  - Installing without the `@rc5` pin pulls a version this guide does not describe
+  - Even the pin can go stale — when something here doesn't match reality (an export is missing, a
+    config shape errors), check `npm view drizzle-orm dist-tags --json` for the current tag before
+    assuming the code below is wrong
+  - The `rc5` tag resolves to a snapshot build with no matching GitHub release, so the releases feed
+    lags what you actually install
+
+## Documentation
+
+- Drizzle
+  - Reference: https://orm.drizzle.team/llms.txt
+  - Changelog: https://github.com/drizzle-team/drizzle-orm/releases
+- Bun SQLite
+  - Reference: https://bun.com/docs/runtime/sqlite.md
+  - Changelog: omitted — Bun publishes no per-module changelog, and its release posts are dominated
+    by unrelated runtime changes
+
+Read these before going beyond what the steps below cover.
+
+## 0. Check it isn't already set up
+
+If `drizzle.config.ts` exists at the project root, Drizzle is already configured. Stop here, tell
+the user what's already in place, and ask what they actually want changed — do not re-run the
+steps below, they will overwrite an existing schema.
+
+## 1. Install dependencies
+
+```bash
+bun add drizzle-orm@rc5
+bun add -d drizzle-kit@rc5
+```
+
+- `drizzle-kit` — the CLI for schema pushes, migrations, and Drizzle Studio, so it stays a dev
+  dependency
+
+## 2. Add scripts
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "drizzle:push": "bun --bun drizzle-kit push",
+    "drizzle:studio": "bun --bun drizzle-kit studio"
+  }
+}
+```
+
+- `bun --bun` — resolves the SQLite driver through Bun's runtime rather than a Node.js shim
+
+## 3. Configure environment
+
+Add `DATABASE_URL` to the server environment schema in `src/lib/env.server.ts`:
+
+```ts
+import { z } from "zod";
+
+/**
+ * Server-only environment variables.
+ */
+const serverEnvSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+});
+
+export default serverEnvSchema.parse(process.env);
+```
+
+The database path is non-secret configuration, so it belongs in `.env` (committed) rather than
+`.env.local`:
+
+```bash
+DATABASE_URL=file:./local.db
+```
+
+Add the database file to `.gitignore`. Bun's SQLite driver defaults to WAL mode, which creates
+`-shm`/`-wal` sidecar files alongside it — ignore those too:
+
+```
+local.db
+local.db-shm
+local.db-wal
+```
+
+## 4. Create the config
+
+Create `drizzle.config.ts` at the project root:
+
+```ts
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./drizzle",
+  schema: "./src/lib/db.schema.ts",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});
+```
+
+- `process.env.DATABASE_URL` — read directly rather than through `@/lib/env.server`
+  - drizzle-kit runs outside the app, so it can't resolve the `@/` path alias
+  - Bun loads `.env` automatically, so the variable is populated when the `drizzle:*` scripts run
+
+## 5. Define the schema
+
+Create `src/lib/db.schema.ts`. Ask the user what they're modelling and write tables for that. The
+example below is two tables, since relations (next section) need at least one foreign key to
+demonstrate:
+
+```ts
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const foldersTable = sqliteTable("folders", {
+  id: int().primaryKey({ autoIncrement: true }),
+  name: text().notNull(),
+});
+
+export const notesTable = sqliteTable("notes", {
+  id: int().primaryKey({ autoIncrement: true }),
+  folderId: int().references(() => foldersTable.id),
+  content: text().notNull(),
+  createdAt: int({ mode: "timestamp_ms" }).notNull(),
+  updatedAt: int({ mode: "timestamp_ms" }).notNull(),
+});
+```
+
+`int({ mode: "timestamp_ms" })` stores timestamps as milliseconds since epoch and maps them to JS
+`Date` objects — assign `new Date()` or `Date.now()` directly.
+
+### Relations
+
+Append to `src/lib/db.schema.ts` (add `defineRelations` to the existing `drizzle-orm` import):
+
+```ts
+import { defineRelations } from "drizzle-orm";
+
+const schema = { foldersTable, notesTable };
+
+export const relations = defineRelations(schema, (r) => ({
+  foldersTable: {
+    notes: r.many.notesTable({
+      from: r.foldersTable.id,
+      to: r.notesTable.folderId,
+    }),
+  },
+  notesTable: {
+    folder: r.one.foldersTable({
+      from: r.notesTable.folderId,
+      to: r.foldersTable.id,
+      optional: true,
+    }),
+  },
+}));
+```
+
+- `defineRelations()` — the relational API as of `@rc5`, replacing the `relations()` helper that
+  older Drizzle docs and tutorials use
+  - `relations()` is not exported from `drizzle-orm` in this version
+  - Importing it fails at runtime rather than at the type level, so it surfaces only once the code
+    actually runs
+  - The relational API changed shape once during the beta/rc cycle and may change again
+
+For a many-to-many relation through a join table, chain `.through()` on both sides' columns instead
+of writing relations on the join table itself — `db.query` then traverses the join table
+implicitly. Illustrative only; `tagsTable`/`noteTagsTable` aren't part of the example schema above:
+
+```ts
+tagsTable: {
+  notes: r.many.notesTable({
+    from: r.tagsTable.id.through(r.noteTagsTable.tagId),
+    to: r.notesTable.id.through(r.noteTagsTable.noteId),
+  }),
+},
+```
+
+## 6. Create the client
+
+Create `src/lib/db.server.ts`:
+
+```ts
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { relations } from "@/lib/db.schema";
+import env from "@/lib/env.server";
+
+export const db = drizzle(env.DATABASE_URL, { relations });
+```
+
+- `drizzle-orm/bun-sqlite` — the Bun-native driver, rather than the generic sqlite adapter
+- `import env from` — `env.server.ts` uses a default export, so the named form fails
+- `relations` — the only schema key this driver's config accepts
+  - Passing `{ schema }`, as older Drizzle examples do, is a type error here; pass the object
+    `defineRelations()` returned instead
+  - `relations` is what powers `db.query`. The plain query builder (`db.select().from(...)`) works
+    without it, but `defineRelations` costs little, so there's rarely a reason to skip it
+
+## 7. Use it in `src/lib`
+
+`db.server.ts` is server-only, so import it from other `*.server.ts` modules and expose the results
+through server functions, following the existing `src/lib` domain convention:
+
+```ts
+// src/lib/notes.server.ts
+import { db } from "@/lib/db.server";
+import { notesTable } from "@/lib/db.schema";
+
+export async function listNotes() {
+  return await db.select().from(notesTable);
+}
+```
+
+```ts
+// src/lib/notes.functions.ts
+import { createServerFn } from "@tanstack/react-start";
+
+import { listNotes } from "@/lib/notes.server";
+
+export const listNotesFn = createServerFn().handler(() => listNotes());
+```
+
+## 8. Document the convention
+
+Add a `Database` section to the project's `CLAUDE.md`, so future changes (and the agent making
+them) stay aligned with the relational API this version of Drizzle actually has:
+
+```md
+## Database
+
+- This project uses Drizzle ORM with Bun's native SQLite driver, see [the documentation](https://orm.drizzle.team/llms.txt)
+- Schema and relations live in `src/lib/db.schema.ts`. Relations use `defineRelations()` — check
+  the docs above before assuming the older `relations()` helper still applies; this package is
+  pre-1.0 and its relational API has already changed shape once.
+- `bun drizzle:push` applies schema changes directly in development — no migration files. For
+  production, use `drizzle-kit generate` then `drizzle-kit migrate` instead.
+- Browse the database with `bun drizzle:studio`.
+```
+
+## 9. Push the schema and verify
+
+```bash
+bun drizzle:push
+bun run format
+bun run build
+```
+
+`drizzle:push` is the development fast path: no migration files, just push and query. For
+production, use `drizzle-kit generate` to produce tracked SQL migration files, then
+`drizzle-kit migrate` to apply them.
+
+Browse the database in Drizzle Studio with `bun drizzle:studio`.

--- a/.claude/skills/setup-drizzle/SKILL.md
+++ b/.claude/skills/setup-drizzle/SKILL.md
@@ -72,6 +72,7 @@ import { z } from "zod";
  */
 const serverEnvSchema = z.object({
   DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  // ...existing keys
 });
 
 export default serverEnvSchema.parse(process.env);

--- a/.claude/skills/setup-drizzle/SKILL.md
+++ b/.claude/skills/setup-drizzle/SKILL.md
@@ -140,7 +140,7 @@ export const notesTable = sqliteTable("notes", {
 `int({ mode: "timestamp_ms" })` stores timestamps as milliseconds since epoch and maps them to JS
 `Date` objects — assign `new Date()` or `Date.now()` directly.
 
-### Relations
+### 5.1 Relations
 
 Append to `src/lib/db.schema.ts` (add `defineRelations` to the existing `drizzle-orm` import):
 

--- a/.claude/skills/setup-drizzle/SKILL.md
+++ b/.claude/skills/setup-drizzle/SKILL.md
@@ -32,8 +32,8 @@ Read these before going beyond what the steps below cover.
 ## 0. Check it isn't already set up
 
 If `drizzle.config.ts` exists at the project root, Drizzle is already configured. Stop here, tell
-the user what's already in place, and ask what they actually want changed — do not re-run the
-steps below, they will overwrite an existing schema.
+the user what's already in place, and ask what they actually want changed — do not re-run the steps
+below, they will overwrite an existing schema.
 
 ## 1. Install dependencies
 
@@ -174,8 +174,8 @@ export const relations = defineRelations(schema, (r) => ({
   - The relational API changed shape once during the beta/rc cycle and may change again
 
 For a many-to-many relation through a join table, chain `.through()` on both sides' columns instead
-of writing relations on the join table itself — `db.query` then traverses the join table
-implicitly. Illustrative only; `tagsTable`/`noteTagsTable` aren't part of the example schema above:
+of writing relations on the join table itself — `db.query` then traverses the join table implicitly.
+Illustrative only; `tagsTable`/`noteTagsTable` aren't part of the example schema above:
 
 ```ts
 tagsTable: {
@@ -233,16 +233,17 @@ export const listNotesFn = createServerFn().handler(() => listNotes());
 
 ## 8. Document the convention
 
-Add a `Database` section to the project's `CLAUDE.md`, so future changes (and the agent making
-them) stay aligned with the relational API this version of Drizzle actually has:
+Add a `Database` section to the project's `CLAUDE.md`, so future changes (and the agent making them)
+stay aligned with the relational API this version of Drizzle actually has:
 
 ```md
 ## Database
 
-- This project uses Drizzle ORM with Bun's native SQLite driver, see [the documentation](https://orm.drizzle.team/llms.txt)
-- Schema and relations live in `src/lib/db.schema.ts`. Relations use `defineRelations()` — check
-  the docs above before assuming the older `relations()` helper still applies; this package is
-  pre-1.0 and its relational API has already changed shape once.
+- This project uses Drizzle ORM with Bun's native SQLite driver, see
+  [the documentation](https://orm.drizzle.team/llms.txt)
+- Schema and relations live in `src/lib/db.schema.ts`. Relations use `defineRelations()` — check the
+  docs above before assuming the older `relations()` helper still applies; this package is pre-1.0
+  and its relational API has already changed shape once.
 - `bun drizzle:push` applies schema changes directly in development — no migration files. For
   production, use `drizzle-kit generate` then `drizzle-kit migrate` instead.
 - Browse the database with `bun drizzle:studio`.

--- a/.claude/skills/setup-markdown/SKILL.md
+++ b/.claude/skills/setup-markdown/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: setup-markdown
-description: Render Markdown content with TanStack Markdown, TanStack Highlight (for code highlighting) shadcn's Typeset (for prose styling)
+description:
+  Render Markdown content with TanStack Markdown, TanStack Highlight (for code highlighting)
+  shadcn's Typeset (for prose styling)
 ---
 
 # Setup Markdown
@@ -97,8 +99,8 @@ rendered (see step 5):
 
 ## 3. Configure the syntax highlighter
 
-Create `src/lib/highlight.ts`. Import only the languages the project's markdown actually uses —
-each one adds to the bundle:
+Create `src/lib/highlight.ts`. Import only the languages the project's markdown actually uses — each
+one adds to the bundle:
 
 ```ts
 import { createHighlighter } from "@tanstack/highlight/core";
@@ -123,7 +125,8 @@ export const highlightMarkdownCode = createTanStackMarkdownHighlighter(highlight
 ```
 
 - `createTanStackMarkdownHighlighter` adapts the highlighter to `@tanstack/markdown`'s `highlighter`
-  render option — it emits escaped inner token markup, since Markdown owns the `<pre><code>` wrapper.
+  render option — it emits escaped inner token markup, since Markdown owns the `<pre><code>`
+  wrapper.
 - `createThemeCss` generates the CSS variables and base styles for the theme, scoped by selector.
   `darkSelector: ":root"` above always applies the dark theme; pass both `light` and `dark` themes
   with selectors that match the project's actual dark-mode toggle (e.g. `darkSelector: ".dark"`) to

--- a/.claude/skills/setup-markdown/SKILL.md
+++ b/.claude/skills/setup-markdown/SKILL.md
@@ -258,7 +258,21 @@ function RouteComponent() {
 }
 ```
 
-## 6. Verify
+## 6. Document the convention
+
+Add a `Markdown` section to the project's `CLAUDE.md`, so future content types stay consistent with
+this setup:
+
+```md
+## Markdown
+
+- Register any new code highlighting languages in `src/lib/highlight.ts`'s `languages` array before
+  using them in content.
+- Wrap every render site in the `typeset typeset-docs` classes, and inject `highlightCss` through
+  the route's `head` — see `src/routes/posts.$slug.tsx`.
+```
+
+## 7. Verify
 
 ```bash
 bun run format

--- a/.claude/skills/setup-markdown/SKILL.md
+++ b/.claude/skills/setup-markdown/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: setup-markdown
+description: Render Markdown content with TanStack Markdown, TanStack Highlight (for code highlighting) shadcn's Typeset (for prose styling)
+---
+
+# Setup Markdown
+
+One-time setup that adds Markdown rendering: TanStack Markdown to parse and render, TanStack
+Highlight for fenced code blocks, and shadcn Typeset for prose styling.
+
+## Important Caveats
+
+- Both TanStack packages are 0.0.x, so their APIs can change between any two patch releases
+  - Neither publishes a usable changelog, so a break surfaces as a failing build rather than a
+    release note
+  - Check the installed versions against the references below when something here doesn't match
+
+## Documentation
+
+- TanStack Markdown
+  - Reference: https://tanstack.com/markdown/latest/llms.txt
+  - Changelog: omitted — the repo publishes no releases, tags, or changelog
+- TanStack Highlight
+  - Reference: https://tanstack.com/highlight/latest/llms.txt
+  - Changelog: omitted — the releases page stops at v0.0.5 while npm ships 0.0.10, so it misleads
+    rather than informs
+- shadcn Typeset
+  - Reference: https://ui.shadcn.com/docs/typeset
+  - Changelog: https://ui.shadcn.com/docs/changelog
+
+Read these before going beyond what the steps below cover.
+
+## 0. Check it isn't already set up
+
+If `src/lib/highlight.ts` or `src/typeset.css` exists, this is already configured. Stop here, tell
+the user what's already in place, and ask what they want changed.
+
+## 1. Install dependencies
+
+```bash
+bun add @tanstack/markdown @tanstack/highlight
+```
+
+Code blocks need a monospace font. This project only imports the Geist sans variable font, so add
+the mono companion too:
+
+```bash
+bun add @fontsource-variable/geist-mono
+```
+
+## 2. Add shadcn Typeset
+
+[Typeset](https://ui.shadcn.com/docs/typeset) is a single CSS file you own, not a component
+installed via the shadcn CLI. Download it into `src/typeset.css`:
+
+```bash
+curl -o src/typeset.css https://ui.shadcn.com/typeset.css
+```
+
+Run `bun run format` afterwards so oxfmt reflows it to match the project's formatting.
+
+Import it after the Tailwind and font imports in `src/styles.css`, adding the mono font alongside:
+
+```css
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
+@import "./typeset.css";
+```
+
+Register the mono font as a theme token in the existing `@theme inline` block — the project defines
+`--font-sans` but not `--font-mono`, and the preset below needs it:
+
+```css
+@theme inline {
+  --font-mono: "Geist Mono Variable", monospace;
+  /* ...existing tokens */
+}
+```
+
+`.typeset` alone only sets sane defaults (`1em`, `inherit`). Add a preset class in `src/styles.css`
+that maps the project's actual design tokens, and use it alongside `.typeset` wherever markdown is
+rendered (see step 5):
+
+```css
+.typeset-docs {
+  --typeset-font-body: var(--font-sans);
+  --typeset-font-heading: var(--font-heading);
+  --typeset-font-mono: var(--font-mono);
+  --typeset-size: 15px;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
+```
+
+## 3. Configure the syntax highlighter
+
+Create `src/lib/highlight.ts`. Import only the languages the project's markdown actually uses —
+each one adds to the bundle:
+
+```ts
+import { createHighlighter } from "@tanstack/highlight/core";
+import { json } from "@tanstack/highlight/languages/json";
+import { shell } from "@tanstack/highlight/languages/shell";
+import { ts } from "@tanstack/highlight/languages/ts";
+import { tsx } from "@tanstack/highlight/languages/tsx";
+import { createTanStackMarkdownHighlighter } from "@tanstack/highlight/markdown";
+import { createThemeCss } from "@tanstack/highlight/theme";
+import { githubDarkTheme } from "@tanstack/highlight/themes/github-dark";
+
+const highlighter = createHighlighter({
+  languages: [json, shell, tsx, ts],
+});
+
+export const highlightCss = createThemeCss({
+  dark: githubDarkTheme,
+  darkSelector: ":root",
+});
+
+export const highlightMarkdownCode = createTanStackMarkdownHighlighter(highlighter);
+```
+
+- `createTanStackMarkdownHighlighter` adapts the highlighter to `@tanstack/markdown`'s `highlighter`
+  render option — it emits escaped inner token markup, since Markdown owns the `<pre><code>` wrapper.
+- `createThemeCss` generates the CSS variables and base styles for the theme, scoped by selector.
+  `darkSelector: ":root"` above always applies the dark theme; pass both `light` and `dark` themes
+  with selectors that match the project's actual dark-mode toggle (e.g. `darkSelector: ".dark"`) to
+  support both. Available themes are listed under `@tanstack/highlight/themes/*`.
+- The default `codeBlockSelector`/`lineNumbersSelector` already match TanStack Markdown's emitted
+  `pre.tm-code` wrapper, so no extra config is needed for that pairing.
+
+## 4. Parse and expose markdown content
+
+Follow the `src/lib` domain convention (`<domain>.schemas.ts`, `<domain>.server.ts`,
+`<domain>.functions.ts`) for whatever markdown content the project renders — posts, docs pages, etc.
+Ask the user what they're rendering and adjust the domain name and source (filesystem, CMS,
+database) to fit. The example below reads `.md` files from a `posts/` directory at the project root.
+
+### 4.1 Define the frontmatter schema
+
+`src/lib/posts.schemas.ts`:
+
+```ts
+import { z } from "zod";
+
+export const postFrontmatterSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+});
+```
+
+### 4.2 Read and parse the markdown files
+
+`src/lib/posts.server.ts` parses the frontmatter block with `parseMarkdown`'s `frontmatter: true`
+option, then decodes it with Bun's built-in YAML parser:
+
+```ts
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { parseMarkdown } from "@tanstack/markdown/parser";
+import { YAML } from "bun";
+
+import { postFrontmatterSchema } from "@/lib/posts.schemas";
+
+const POSTS_DIR = resolve("posts");
+
+/**
+ * Gets a single post, including its parsed document.
+ *
+ * @param slug - The post's slug, excluding the file extension, e.g. `hello-world`.
+ */
+export async function getPost(slug: string) {
+  const content = await readFile(resolve(POSTS_DIR, `${slug}.md`), "utf-8");
+  const document = parseMarkdown(content, { frontmatter: true });
+  const frontmatter = postFrontmatterSchema.parse(YAML.parse(document.frontmatter ?? ""));
+
+  return { slug, ...frontmatter, document };
+}
+
+/**
+ * Lists the available posts by reading the contents of the posts directory.
+ */
+export async function listPosts() {
+  const entries = await readdir(POSTS_DIR);
+  const slugs = entries
+    .filter((entry) => entry.endsWith(".md"))
+    .map((entry) => entry.replace(".md", ""));
+
+  const posts = await Promise.all(slugs.map((slug) => getPost(slug)));
+  // Don't include the parsed document in the list, since it's not needed for a listing and can be large.
+  return posts.map(({ document: _document, ...post }) => post);
+}
+```
+
+`listPosts` reuses `getPost` for every file rather than duplicating the parse. Each post is still
+fully parsed so its frontmatter gets validated, but the destructured `document` is dropped before
+the array is returned: a listing only needs the frontmatter, and shipping every post's full parsed
+AST over the wire for a page that just renders titles and descriptions would be wasteful.
+
+Parse once here rather than on every render — `document` is a plain serializable object that can be
+returned straight through a server function and rendered by `<Markdown>` without reparsing.
+
+### 4.3 Expose them through server functions
+
+`src/lib/posts.functions.ts`:
+
+```ts
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import { getPost, listPosts } from "@/lib/posts.server";
+
+export const listPostsFn = createServerFn().handler(() => listPosts());
+
+export const getPostFn = createServerFn()
+  .validator(z.string())
+  .handler(({ data: slug }) => getPost(slug));
+```
+
+## 5. Render the markdown
+
+Render the parsed document with `<Markdown>`, wrapped in the `typeset` and preset classes from
+step 2. Inject `highlightCss` through the route's `head` so highlighted code blocks are themed.
+
+`src/routes/posts.$slug.tsx`:
+
+```tsx
+import { Markdown } from "@tanstack/markdown/react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { highlightCss, highlightMarkdownCode } from "@/lib/highlight";
+import { getPostFn } from "@/lib/posts.functions";
+
+export const Route = createFileRoute("/posts/$slug")({
+  head: () => ({
+    styles: [{ children: highlightCss }],
+  }),
+  component: RouteComponent,
+  loader: async ({ params }) => {
+    const post = await getPostFn({ data: params.slug });
+    return { post };
+  },
+});
+
+function RouteComponent() {
+  const { post } = Route.useLoaderData();
+  return (
+    <div className="typeset typeset-docs">
+      <Markdown highlighter={highlightMarkdownCode}>{post.document}</Markdown>
+    </div>
+  );
+}
+```
+
+## 6. Verify
+
+```bash
+bun run format
+bun run build
+```
+
+Then run `bun dev` and load a post route — confirm the prose is styled and code blocks are
+highlighted, not just plain `<pre>` text.

--- a/.claude/skills/setup-vercel-static-hosting/SKILL.md
+++ b/.claude/skills/setup-vercel-static-hosting/SKILL.md
@@ -28,8 +28,8 @@ Read these before going beyond what the steps below cover.
 
 ## 0. Check it isn't already set up
 
-If `vercel.json` exists at the project root, Vercel hosting is already configured.
-Stop here, tell the user what's already in place, and ask what they want changed.
+If `vercel.json` exists at the project root, Vercel hosting is already configured. Stop here, tell
+the user what's already in place, and ask what they want changed.
 
 ## 1. Create the `vercel.json` file
 
@@ -56,11 +56,13 @@ Stop here, tell the user what's already in place, and ask what they want changed
 
 - `framework: null` stops Vercel's framework detection from overriding the explicit commands above.
 - The long-lived `Cache-Control` on `/assets/` is safe because Vite adds a hash to those filenames.
-- Confirm `outputDirectory` matches where the build actually writes — check `dist/` after a build if unsure.
+- Confirm `outputDirectory` matches where the build actually writes — check `dist/` after a build if
+  unsure.
 
 ## 2. Configure prerendering in `vite.config.ts`
 
-Set the `prerender` option on the `tanstackStart` plugin. The plugin is currently called with no arguments, so add the options object:
+Set the `prerender` option on the `tanstackStart` plugin. The plugin is currently called with no
+arguments, so add the options object:
 
 ```ts
 export default defineConfig({
@@ -93,5 +95,5 @@ export default defineConfig({
 bun run build
 ```
 
-Confirm the build wrote prerendered HTML into `dist/client`,
-not just the JS bundle — if only `index.html` is there, prerendering didn't pick up the other routes.
+Confirm the build wrote prerendered HTML into `dist/client`, not just the JS bundle — if only
+`index.html` is there, prerendering didn't pick up the other routes.

--- a/.claude/skills/setup-vercel-static-hosting/SKILL.md
+++ b/.claude/skills/setup-vercel-static-hosting/SKILL.md
@@ -92,6 +92,7 @@ export default defineConfig({
 ## 3. Verify
 
 ```bash
+bun run format
 bun run build
 ```
 

--- a/.claude/skills/setup-vercel-static-hosting/SKILL.md
+++ b/.claude/skills/setup-vercel-static-hosting/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: setup-vercel-static-hosting
+description: Configures the app to deploy to Vercel as a static site
+---
+
+# Setup Vercel Static Hosting
+
+One-time setup that configures Vercel to build and serve this project as a static site.
+
+## Important Caveats
+
+- This targets **static** hosting — every route is prerendered at build time and served as HTML
+  - When the app needs server functions or SSR at request time, ask the user whether they want a
+    server deployment before continuing
+
+## Documentation
+
+- Vercel configuration
+  - Reference: https://vercel.com/docs/project-configuration/vercel-json.md
+  - Changelog: omitted — Vercel's changelog carries product announcements and has no signal for
+    `vercel.json` keys
+- TanStack Start prerendering
+  - Reference: https://tanstack.com/start/latest/docs/framework/react/guide/static-prerendering.md
+  - Changelog: omitted — Start ships from the `TanStack/router` monorepo, which publishes several
+    package-wide releases a day
+
+Read these before going beyond what the steps below cover.
+
+## 0. Check it isn't already set up
+
+If `vercel.json` exists at the project root, Vercel hosting is already configured.
+Stop here, tell the user what's already in place, and ask what they want changed.
+
+## 1. Create the `vercel.json` file
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "bun install --frozen-lockfile",
+  "buildCommand": "bun run build",
+  "outputDirectory": "dist/client",
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `framework: null` stops Vercel's framework detection from overriding the explicit commands above.
+- The long-lived `Cache-Control` on `/assets/` is safe because Vite adds a hash to those filenames.
+- Confirm `outputDirectory` matches where the build actually writes — check `dist/` after a build if unsure.
+
+## 2. Configure prerendering in `vite.config.ts`
+
+Set the `prerender` option on the `tanstackStart` plugin. The plugin is currently called with no arguments, so add the options object:
+
+```ts
+export default defineConfig({
+  server: {
+    port: Number(process.env.PORT) || 3000,
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
+  plugins: [
+    tailwindcss(),
+    tanstackStart({
+      prerender: {
+        enabled: true,
+        crawlLinks: true,
+      },
+    }),
+    react(),
+  ],
+});
+```
+
+- `crawlLinks: true` — follows links from the entry routes to discover pages to prerender
+  - Routes not reachable by a link, or behind dynamic params, won't be found; list those explicitly
+    via the plugin's `pages` option when the app has any
+
+## 3. Verify
+
+```bash
+bun run build
+```
+
+Confirm the build wrote prerendered HTML into `dist/client`,
+not just the JS bundle — if only `index.html` is there, prerendering didn't pick up the other routes.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "ignorePatterns": ["*.gen.ts"],
+  "proseWrap": "always",
   "sortImports": true,
   "sortTailwindcss": {
     "stylesheet": "./src/styles.css",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,13 @@
 Before editing files for a substantial task:
 
 - Run `bunx @tanstack/intent@latest list` from the workspace root to see available local skills.
-- If a listed skill matches the task, run `bunx @tanstack/intent@latest load <package>#<skill>` before changing files.
+- If a listed skill matches the task, run `bunx @tanstack/intent@latest load <package>#<skill>`
+  before changing files.
 - Use the loaded `SKILL.md` guidance while making the change.
-- Monorepos: when working across packages, run the skill check from the workspace root and prefer the local skill for the package being changed.
-- Multiple matches: prefer the most specific local skill for the package or concern you are changing; load additional skills only when the task spans multiple packages or concerns.
+- Monorepos: when working across packages, run the skill check from the workspace root and prefer
+  the local skill for the package being changed.
+- Multiple matches: prefer the most specific local skill for the package or concern you are
+  changing; load additional skills only when the task spans multiple packages or concerns.
 
 <!-- intent-skills:end -->
 
@@ -26,13 +29,18 @@ Before editing files for a substantial task:
 
 ## Project Structure
 
-- `src/lib` contains the project's library code, grouped by domain via this naming convention (e.g. for a `todos` domain):
-  - `todos.server.ts` — server-only code, usually paired with `todos.server.test.ts` to unit test it.
-  - `todos.functions.ts` — a thin wrapper exposing server functions, importing from `todos.server.ts`.
+- `src/lib` contains the project's library code, grouped by domain via this naming convention (e.g.
+  for a `todos` domain):
+  - `todos.server.ts` — server-only code, usually paired with `todos.server.test.ts` to unit test
+    it.
+  - `todos.functions.ts` — a thin wrapper exposing server functions, importing from
+    `todos.server.ts`.
   - `todos.schemas.ts` — Zod schemas for the domain.
-  - `todos.ts` — isomorphic code that can run on either the client or server (e.g. date helpers), usually paired with `todos.test.ts` to unit test it.
+  - `todos.ts` — isomorphic code that can run on either the client or server (e.g. date helpers),
+    usually paired with `todos.test.ts` to unit test it.
 - Environment variables are validated with Zod, and must be added to the relevant schema before use:
-  - `src/lib/env.ts` — client-readable variables, which must be prefixed with `VITE_`. Values come from `.env` (committed) and `.env.local` (gitignored, for secrets).
+  - `src/lib/env.ts` — client-readable variables, which must be prefixed with `VITE_`. Values come
+    from `.env` (committed) and `.env.local` (gitignored, for secrets).
   - `src/lib/env.server.ts` — server-only variables.
 
 ## Coding Preferences
@@ -40,7 +48,9 @@ Before editing files for a substantial task:
 - Apply the YAGNI and KISS principles
 - Keep things simple, robust and readable
 - Keep comments up to date with code changes
-- Exports benefit from a short tsdoc comment describing intent and any non-obvious behaviour. Not required for every export — use judgment based on complexity. When you do add one, use the following format:
+- Exports benefit from a short tsdoc comment describing intent and any non-obvious behaviour. Not
+  required for every export — use judgment based on complexity. When you do add one, use the
+  following format:
   ```ts
   /**
    * <short description>
@@ -64,17 +74,23 @@ Before editing files for a substantial task:
 
 ## Testing
 
-- Always use Bun's test runner (`bun test`), see [the documentation](https://bun.com/docs/test.md) for more information.
-- Before writing tests, extract pure functions and presentational components out of framework wrappers (e.g. `createServerFn`, route files) so tests don't need runtime context.
+- Always use Bun's test runner (`bun test`), see [the documentation](https://bun.com/docs/test.md)
+  for more information.
+- Before writing tests, extract pure functions and presentational components out of framework
+  wrappers (e.g. `createServerFn`, route files) so tests don't need runtime context.
 
 ## User Interface
 
-- This project uses [shadcn/ui](https://ui.shadcn.com) components built on Tailwind CSS (v4) and Base UI.
+- This project uses [shadcn/ui](https://ui.shadcn.com) components built on Tailwind CSS (v4) and
+  Base UI.
 - `components.json` configures the shadcn CLI (style, aliases, icon library).
 - Use `bun shadcn add <component>` to add new components.
 - Tailwind is configured CSS-first via `src/styles.css`
-- Tailwind class sorting is handled by Oxfmt's `sortTailwindcss` option in `.oxfmtrc.json`, so classes are reordered automatically on format.
-- **Do not use `<Button render={<a />} nativeButton={false} />` for links.** The Base UI `Button` component always applies `role="button"`, which overrides the semantic link role on `<a>` elements. Use `buttonVariants` with a plain `<a>` tag instead.
+- Tailwind class sorting is handled by Oxfmt's `sortTailwindcss` option in `.oxfmtrc.json`, so
+  classes are reordered automatically on format.
+- **Do not use `<Button render={<a />} nativeButton={false} />` for links.** The Base UI `Button`
+  component always applies `role="button"`, which overrides the semantic link role on `<a>`
+  elements. Use `buttonVariants` with a plain `<a>` tag instead.
 
 ## Pull requests
 
@@ -97,7 +113,8 @@ Before editing files for a substantial task:
 
   <!-- list of checkboxes for testing -->
   ```
-- Use the following branch naming convention: `<type>/<short-description>`, where `<type>` is one of:
+- Use the following branch naming convention: `<type>/<short-description>`, where `<type>` is one
+  of:
   - `feature` — for new features
   - `fix` — for bug fixes
   - `refactor` — for refactoring existing code

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ bun dev
 bun run update
 ```
 
+## Set up additional tooling
+
+There are a few additional tools that can be configured via agent skills.
+
+- [`/setup-drizzle`](./.claude/skills/setup-drizzle/SKILL.md)
+- [`/setup-markdown`](./.claude/skills/setup-markdown/SKILL.md)
+- [`/setup-vercel-static-hosting`](./.claude/skills/setup-vercel-static-hosting/SKILL.md)
+
 ## Environment variables
 
 Environment variables can be configured in one of two files:
@@ -72,6 +80,10 @@ Environment variables can be configured in one of two files:
 - `.env.local` for secret configuration, this is gitignored. Copy `.env.local.example` to get started.
 
 ## Common Tasks
+
+### Add a new setup skill
+
+Set the tool up by hand first, then run [`/draft-setup-skill`](./.claude/skills/draft-setup-skill/SKILL.md) to capture it as a reusable `/setup-*` skill from the changes on disk.
 
 ### Update skills
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Environment variables can be configured in one of two files:
 
 Set the tool up by hand first, then run [`/draft-setup-skill`](./.claude/skills/draft-setup-skill/SKILL.md) to capture it as a reusable `/setup-*` skill from the changes on disk.
 
+### Review setup skills
+
+Run [`/review-setup-skills`](./.claude/skills/review-setup-skills/SKILL.md) to check one or all `/setup-*` skills against the template and against the upstream libraries' current docs, and fix what's drifted. Pass a skill name to review just that one.
+
 ### Update skills
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,17 +77,22 @@ There are a few additional tools that can be configured via agent skills.
 Environment variables can be configured in one of two files:
 
 - `.env` for non-secret configuration, this is committed in git
-- `.env.local` for secret configuration, this is gitignored. Copy `.env.local.example` to get started.
+- `.env.local` for secret configuration, this is gitignored. Copy `.env.local.example` to get
+  started.
 
 ## Common Tasks
 
 ### Add a new setup skill
 
-Set the tool up by hand first, then run [`/draft-setup-skill`](./.claude/skills/draft-setup-skill/SKILL.md) to capture it as a reusable `/setup-*` skill from the changes on disk.
+Set the tool up by hand first, then run
+[`/draft-setup-skill`](./.claude/skills/draft-setup-skill/SKILL.md) to capture it as a reusable
+`/setup-*` skill from the changes on disk.
 
 ### Review setup skills
 
-Run [`/review-setup-skills`](./.claude/skills/review-setup-skills/SKILL.md) to check one or all `/setup-*` skills against the template and against the upstream libraries' current docs, and fix what's drifted. Pass a skill name to review just that one.
+Run [`/review-setup-skills`](./.claude/skills/review-setup-skills/SKILL.md) to check one or all
+`/setup-*` skills against the template and against the upstream libraries' current docs, and fix
+what's drifted. Pass a skill name to review just that one.
 
 ### Update skills
 

--- a/VISION.md
+++ b/VISION.md
@@ -24,5 +24,5 @@ This template captures those decisions so that you can clone it and start buildi
 
 ## Roadmap
 
-1. Add built-in agent skills for configuring common things, like databases, deployment, etc.
+1. Expand the built-in setup skills ([.claude/skills/](./.claude/skills/)) beyond the current database, markdown, and hosting ones — e.g. Docker, auth, a test framework
 2. Custom theme?

--- a/VISION.md
+++ b/VISION.md
@@ -2,27 +2,34 @@
 
 ## What this is
 
-An opinionated starting point for full-stack applications, pre-configured with common tooling and best practices allowing you to hit the ground running with new projects.
+An opinionated starting point for full-stack applications, pre-configured with common tooling and
+best practices allowing you to hit the ground running with new projects.
 
 ## Why it exists
 
-Setting up a new project can involve setting up build tools, frameworks, libraries and other tooling.
-This template captures those decisions so that you can clone it and start building your app immediately.
+Setting up a new project can involve setting up build tools, frameworks, libraries and other
+tooling. This template captures those decisions so that you can clone it and start building your app
+immediately.
 
 ## Goals
 
 - Clone-to-running in minutes, with a documented setup checklist ([README.md](README.md))
 - Easily keep your app up to date with template improvements
-- A opinionated project structure (`src/lib` domain modules split into server/functions/schemas/isomorphic) that scales as an app grows
-- Encode agent-facing conventions (CLAUDE.md, skills) so AI-assisted work on downstream apps starts from the same good defaults
+- A opinionated project structure (`src/lib` domain modules split into
+  server/functions/schemas/isomorphic) that scales as an app grows
+- Encode agent-facing conventions (CLAUDE.md, skills) so AI-assisted work on downstream apps starts
+  from the same good defaults
 - Have a CI pipeline that works out of the box
 
 ## Non-goals
 
-- Backwards compatibility guarantees for downstream apps — breaking changes are okay if they make new projects better; existing apps merge template updates at their own pace
-- Covering every possible app type (e.g. mobile, CLI tools) — this is for web apps built with TanStack Start
+- Backwards compatibility guarantees for downstream apps — breaking changes are okay if they make
+  new projects better; existing apps merge template updates at their own pace
+- Covering every possible app type (e.g. mobile, CLI tools) — this is for web apps built with
+  TanStack Start
 
 ## Roadmap
 
-1. Expand the built-in setup skills ([.claude/skills/](./.claude/skills/)) beyond the current database, markdown, and hosting ones — e.g. Docker, auth, a test framework
+1. Expand the built-in setup skills ([.claude/skills/](./.claude/skills/)) beyond the current
+   database, markdown, and hosting ones — e.g. Docker, auth, a test framework
 2. Custom theme?

--- a/VISION.md
+++ b/VISION.md
@@ -15,7 +15,7 @@ immediately.
 
 - Clone-to-running in minutes, with a documented setup checklist ([README.md](README.md))
 - Easily keep your app up to date with template improvements
-- A opinionated project structure (`src/lib` domain modules split into
+- An opinionated project structure (`src/lib` domain modules split into
   server/functions/schemas/isomorphic) that scales as an app grows
 - Encode agent-facing conventions (CLAUDE.md, skills) so AI-assisted work on downstream apps starts
   from the same good defaults


### PR DESCRIPTION
## What

Adds skills for creating and maintaining `/setup-*` skills, plus new `/setup-drizzle`, `/setup-markdown`, and `/setup-vercel-static-hosting` skills, and reflows docs to match oxfmt's new prose wrap.

## Why

- Setting up a new tool by hand and turning it into a reusable skill was previously undocumented and ad hoc
- `/setup-*` skills can drift from the template and from upstream library docs over time with nothing to catch it
- Manual markdown line wrapping doesn't stay in sync with edits

## How

- Add `.claude/setup-skill-template.md` as the canonical structure/rules for `/setup-*` skills
- Add `draft-setup-skill` skill: interviews the user about an on-disk change set and writes a new `/setup-*` skill from it
- Add `review-setup-skills` skill: audits one or all `/setup-*` skills against the template and against upstream docs/changelogs, then fixes structural and doc drift
- Add `setup-drizzle`, `setup-markdown`, and `setup-vercel-static-hosting` skills
- Set `proseWrap: "always"` in `.oxfmtrc.json` and let oxfmt reflow `CLAUDE.md`/`README.md`/`VISION.md` instead of manually wrapping them
- Document the new skills in `README.md`, and update `VISION.md`'s roadmap to reflect the skills now in place

## Testing

- [x] `bun run format:check` passes
- [x] No `src/` changes in this branch