### PR TITLE
Add setup, pull-request, and test-app-template skills

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pull-request
+description:
+  Conventions for pull request titles, descriptions, and branch naming. Use this to create or update
+  pull requests.
+---
+
+## Conventions
+
+- Titles should be simple and easy to understand
+- Use the following template for the description:
+  ```md
+  ## What
+
+  <!-- one line summary -->
+
+  ## Why
+
+  <!-- dot point list of reasons for the change -->
+
+  ## How
+
+  <!-- dot point list of how the change was implemented, used nested dot points as required -->
+
+  ## Testing
+
+  <!-- list of checkboxes for testing -->
+  ```
+- Use the following branch naming convention: `<type>/<short-description>`, where `<type>` is one
+  of:
+  - `feature` — for new features
+  - `fix` — for bug fixes
+  - `refactor` — for refactoring existing code
+  - `docs` — for documentation changes
+  - `test` — for test changes
+  - `chore` — for other changes that don't modify src or tests (e.g. build, tooling, dependencies)

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: setup
+description: Configure an integration by following its guide in `docs/setup/`
+argument-hint: "<topic, e.g. drizzle-sqlite>"
+disable-model-invocation: true
+---
+
+Follow the setup guide for `$1` and leave the integration working.
+
+## 1. Resolve the guide
+
+- List `docs/setup/*.md`, excluding `_template.md`, to get the valid topic slugs
+- If `$1` is empty or doesn't match a slug, print the list and stop, do not guess
+- Read `docs/setup/$1.md`
+  - Always read the full guide
+  - If the guide is unclear or incomplete, flag it with the user and stop
+
+## 2. Execute
+
+- Work through the guide's `Steps` section in order (run the commands, create/edit the files it
+  names, etc.)
+- Always follow this project's own conventions (`src/lib` domain file suffixes, Zod env schemas,
+  shadcn/Tailwind rules) from the root `CLAUDE.md`.
+
+## 3. Verify
+
+Work through the guide's `Verification` checklist one item at a time. A step is done only when its
+check passes. If one fails, fix it before moving on.
+
+## 4. Report
+
+Summarize what was installed/configured and which files changed.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -9,6 +9,7 @@ Follow the setup guide for `$1` and leave the integration working.
 
 ## 1. Resolve the guide
 
+- Guides live at `docs/setup/` under the **workspace root**
 - List `docs/setup/*.md`, excluding `_template.md`, to get the valid topic slugs
 - If `$1` is empty or doesn't match a slug, print the list and stop, do not guess
 - Read `docs/setup/$1.md`

--- a/.claude/skills/test-app-template/SKILL.md
+++ b/.claude/skills/test-app-template/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: test-app-template
+description:
+  Test the app template by creating a temporary project. Use this to verify the template and bundled
+  agent skills work as expected.
+argument-hint: "<app name, e.g. my-app>"
+disable-model-invocation: true
+---
+
+1. Use $1 as the name of the project, if the user doesn't provide one, ask for it
+2. Check that `~/Projects/temp` exists, if not, ask the user where they want to create temporary
+   projects
+3. Follow the "Template Setup" section in the `README.md` in the **workspace root**, with these
+   changes:
+   - For the "Clone the template" step, clone the **local workspace root repo** at its **current
+     branch** (run `git branch --show-current` in the workspace root to get it) instead of cloning
+     from the GitHub remote, e.g.
+     `git clone -b <current-branch> <workspace-root> ~/Projects/temp/$1`. This ensures the branch
+     being worked on is tested, not just what's on `main`. Committed but unpushed changes are
+     included; uncommitted changes are not — if any matter for the test, commit them first.
+   - **Skip** the "Push changes" step. Temporary projects should **not** be pushed to GitHub.
+4. Run `bun install`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,30 +94,5 @@ Before editing files for a substantial task:
 
 ## Pull requests
 
-- Titles should be simple and easy to understand
-- Use the following template for the description:
-  ```md
-  ## What
-
-  <!-- one line summary -->
-
-  ## Why
-
-  <!-- dot point list of reasons for the change -->
-
-  ## How
-
-  <!-- dot point list of how the change was implemented, used nested dot points as required -->
-
-  ## Testing
-
-  <!-- list of checkboxes for testing -->
-  ```
-- Use the following branch naming convention: `<type>/<short-description>`, where `<type>` is one
-  of:
-  - `feature` — for new features
-  - `fix` — for bug fixes
-  - `refactor` — for refactoring existing code
-  - `docs` — for documentation changes
-  - `test` — for test changes
-  - `chore` — for other changes that don't modify src or tests (e.g. build, tooling, dependencies)
+- See the `pull-request` skill (`.claude/skills/pull-request/SKILL.md`) for title, description, and
+  branch naming conventions.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Delete this section from the README.md file
 - Setup guides:
   - [Vercel static hosting](./setup/vercel-static-hosting.md) — configure Vercel for static hosting
     of the app
+  - [Drizzle SQLite](./setup/drizzle-sqlite.md) — set up Drizzle with Bun's SQLite driver
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Delete this section from the README.md file
 
 - [VISION.md](./VISION.md) — the purpose and goals of this app
 - Setup guides:
-  - [Vercel static hosting](./docs/setup/vercel-static-hosting.md) — configure Vercel for static hosting
-    of the app
+  - [Vercel static hosting](./docs/setup/vercel-static-hosting.md) — configure Vercel for static
+    hosting of the app
   - [Drizzle SQLite](./docs/setup/drizzle-sqlite.md) — set up Drizzle with Bun's SQLite driver
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Delete this section from the README.md file
 ## Documentation
 
 - [VISION.md](./VISION.md) — the purpose and goals of this app
+- Setup guides:
+  - [Vercel static hosting](./setup/vercel-static-hosting.md) — configure Vercel for static hosting
+    of the app
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Delete this section from the README.md file
 
 - [VISION.md](./VISION.md) — the purpose and goals of this app
 - Setup guides:
-  - [Vercel static hosting](./setup/vercel-static-hosting.md) — configure Vercel for static hosting
+  - [Vercel static hosting](./docs/setup/vercel-static-hosting.md) — configure Vercel for static hosting
     of the app
-  - [Drizzle SQLite](./setup/drizzle-sqlite.md) — set up Drizzle with Bun's SQLite driver
+  - [Drizzle SQLite](./docs/setup/drizzle-sqlite.md) — set up Drizzle with Bun's SQLite driver
 
 ## Getting Started
 

--- a/docs/setup/_template.md
+++ b/docs/setup/_template.md
@@ -1,0 +1,19 @@
+# <integration-name>
+
+Short description of what this configures.
+
+## Steps
+
+### 1. <step-name>
+
+Short description of what needs to be done, include codeblocks.
+
+### 2. <step-name>
+
+## Verification
+
+- [ ] Check that proves the setup worked
+
+## References
+
+- <library-name> docs: <url>

--- a/docs/setup/_template.md
+++ b/docs/setup/_template.md
@@ -2,6 +2,10 @@
 
 Short description of what this configures.
 
+> **Important** (optional)
+>
+> Callout any important information or caveats here
+
 ## Steps
 
 ### 1. <step-name>

--- a/docs/setup/drizzle-sqlite.md
+++ b/docs/setup/drizzle-sqlite.md
@@ -1,0 +1,137 @@
+# Drizzle SQLite
+
+Sets up Drizzle with Bun's SQLite driver.
+
+> **Important**
+>
+> Drizzle is pre-1.0, so install `drizzle-orm@rc5` and `drizzle-kit@rc5` exactly as shown below
+
+## Steps
+
+### 1. Install dependencies
+
+```bash
+bun add drizzle-orm@rc5
+bun add -d drizzle-kit@rc5
+```
+
+### 2. Add scripts to `package.json`
+
+```json
+{
+  "scripts": {
+    "drizzle:push": "bun --bun drizzle-kit push",
+    "drizzle:studio": "bun --bun drizzle-kit studio"
+  }
+}
+```
+
+### 3. Configure environment variables
+
+Add `DATABASE_URL` to the server environment schema in `src/lib/env.server.ts`:
+
+```ts
+import { z } from "zod";
+
+const serverEnvSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  // ...existing keys
+});
+
+export default serverEnvSchema.parse(process.env);
+```
+
+Set `DATABASE_URL` in `.env`:
+
+```bash
+DATABASE_URL=file:./local.db
+```
+
+### 4. Gitignore the database file:
+
+`.gitignore`:
+
+```
+local.db
+```
+
+### 5. Create the `drizzle.config.ts` config file
+
+`drizzle.config.ts`:
+
+```ts
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./drizzle",
+  schema: "./src/lib/db.schema.ts",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});
+```
+
+### 6. Define the schema
+
+> **Agent Notes**
+>
+> Ask the user what they're modelling and write tables for that
+
+Create `src/lib/db.schema.ts` with an example table:
+
+```ts
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const notesTable = sqliteTable("notes", {
+  id: int().primaryKey({ autoIncrement: true }),
+  content: text().notNull(),
+  createdAt: int({ mode: "timestamp_ms" }).notNull(),
+  updatedAt: int({ mode: "timestamp_ms" }).notNull(),
+});
+```
+
+### 7. Create the `db` client
+
+Create `src/lib/db.server.ts`:
+
+```ts
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "@/lib/db.schema";
+import env from "@/lib/env.server";
+
+export const db = drizzle(env.DATABASE_URL, { schema });
+```
+
+### 8. Use it in the app from a server function
+
+create a `src/lib/notes.functions.ts` file:
+
+```ts
+import { createServerFn } from "@tanstack/react-start";
+
+import { db } from "@/lib/db.server";
+import { notesTable } from "@/lib/db.schema";
+
+export const listNotesFn = createServerFn().handler(async () => {
+  return await db.select().from(notesTable);
+});
+```
+
+### 9. Push the schema
+
+```bash
+bun run drizzle:push
+```
+
+## Verification
+
+- [ ] Check `bun run build` runs without errors
+- [ ] Check `local.db` was created
+
+## References
+
+- Drizzle docs: https://orm.drizzle.team/llms.txt
+- Drizzle changelog: https://github.com/drizzle-team/drizzle-orm/releases
+- Bun SQLite docs: https://bun.com/docs/runtime/sqlite.md

--- a/docs/setup/vercel-static-hosting.md
+++ b/docs/setup/vercel-static-hosting.md
@@ -6,8 +6,6 @@ Configures Vercel for static hosting of the app (e.g. static HTML, CSS, JS and a
 
 ### 1. Create the `vercel.json` file
 
-Create a `vercel.json` in the root of the repo:
-
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",

--- a/docs/setup/vercel-static-hosting.md
+++ b/docs/setup/vercel-static-hosting.md
@@ -53,7 +53,7 @@ export default defineConfig({
 
 ## Verification
 
-- [ ] Build the project confirm the prerendered HTML files are generated in `dist/client`.
+- [ ] Build the project and confirm the prerendered HTML files are generated in `dist/client`.
 
 ## References
 

--- a/docs/setup/vercel-static-hosting.md
+++ b/docs/setup/vercel-static-hosting.md
@@ -1,0 +1,62 @@
+# Vercel static hosting
+
+Configures Vercel for static hosting of the app (e.g. static HTML, CSS, JS and assets).
+
+## Steps
+
+### 1. Create the `vercel.json` file
+
+Create a `vercel.json` in the root of the repo:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "bun install --frozen-lockfile",
+  "buildCommand": "bun run build",
+  "outputDirectory": "dist/client",
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Notes**:
+
+- This configures caching for static assets (js, css, fonts, etc.), Vite automatically hashes these
+  files so they can be cached indefinitely.
+
+### 2. Configure prerendering in the `vite.config.ts`
+
+Set the `prerender` option in the `tanstackStart` plugin in `vite.config.ts`:
+
+```ts
+export default defineConfig({
+  ...
+  plugins: [
+    ...
+    tanstackStart({
+      prerender: {
+        enabled: true,
+        crawlLinks: true,
+      },
+    }),
+  ],
+});
+```
+
+## Verification
+
+- [ ] Build the project confirm the prerendered HTML files are generated in `dist/client`.
+
+## References
+
+- `vercel.json` reference: https://vercel.com/docs/project-configuration/vercel-json.md


### PR DESCRIPTION
## What

Add a `setup` skill for running integration guides (backed by `docs/setup/`), a `pull-request` skill extracted from `CLAUDE.md`, and a `test-app-template` skill for verifying the template end-to-end.

## Why

- Integration setup steps (Vercel static hosting, Drizzle SQLite) need a repeatable, guided process instead of ad-hoc instructions
- Keeping PR conventions in a skill (rather than inline in `CLAUDE.md`) keeps the root file lean and makes the conventions independently loadable
- Verifying the template currently requires manual steps; a skill makes that repeatable and safe to run against the current branch without touching GitHub

## How

- Added `.claude/skills/setup/SKILL.md`
  - Resolves a topic to `docs/setup/<topic>.md`, executes its `Steps`, then works through its `Verification` checklist
- Added `docs/setup/_template.md` as the template new setup guides should follow
- Added `docs/setup/vercel-static-hosting.md` and `docs/setup/drizzle-sqlite.md` guides
- Linked both guides from `README.md`
- Added `.claude/skills/pull-request/SKILL.md`
  - Moved the PR title/description/branch-naming conventions out of `CLAUDE.md` into this skill, replacing the section with a pointer to it
- Added `.claude/skills/test-app-template/SKILL.md`
  - Clones the workspace root at its current branch into a temporary project and follows the README's "Template Setup" section
  - Skips the "Push changes" step so temporary test projects are never pushed to GitHub

## Testing

- [x] Run `/setup drizzle-sqlite` and confirm it follows the guide end-to-end
- [x] Run `/setup vercel-static-hosting` and confirm it follows the guide end-to-end
- [x] Confirm `README.md` links to both setup guides resolve correctly
- [x] Run `/test-app-template` and confirm it clones the current branch and completes setup without pushing
